### PR TITLE
Optional install instructions using wstool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ See https://github.com/googlecartographer/cartographer
 
 ## Installation
 
-On Ubuntu 14.04 (Trusty) with ROS Indigo installed:
+Installation has been tested on Ubuntu 14.04 (Trusty) with ROS Indigo. There are multiple options for building cartographer_ros as part of a ROS workspace. Two common use cases are described below.
+
+These dependencies always have to be installed:
 
     # Install the required libraries that are available as debs
     sudo apt-get install \
@@ -20,6 +22,9 @@ On Ubuntu 14.04 (Trusty) with ROS Indigo installed:
       libblas-dev \
       liblapack-dev \
       libpcap-dev  # For 3D SLAM with Velodynes
+
+
+### Standalone Workspace
 
     # Set up your Catkin workspace
     mkdir -p ~/catkin_ws/src
@@ -41,3 +46,17 @@ On Ubuntu 14.04 (Trusty) with ROS Indigo installed:
     cd ~/catkin_ws
     catkin_make_isolated
     source devel_isolated/setup.bash
+
+### Using wstool
+
+If cartographer_ros is to be used as part of a pre-existing workspace/existing project, using [wstool](http://wiki.ros.org/wstool) is recommended.
+
+    # Enter workspace root (i.e. the folder that has "src" as a subfolder)
+    # Merge the cartographer_ros rosinstall file
+    wstool merge https://raw.githubusercontent.com/googlecartographer/cartographer_ros/master/cartographer_ros.rosinstall
+
+    # Update workspace
+    wstool update
+
+    # Build workspace contents. It is recommended to use catkin tools:
+    catkin build

--- a/cartographer_ros.rosinstall
+++ b/cartographer_ros.rosinstall
@@ -1,0 +1,7 @@
+- git: {local-name: src/cartographer, uri: 'https://github.com/googlecartographer/cartographer.git'}
+- git: {local-name: src/cartographer_ros, uri: 'https://github.com/googlecartographer/cartographer_ros.git'}
+- git: {local-name: src/ceres_catkin, uri: 'https://github.com/ethz-asl/ceres_catkin.git'}
+- git: {local-name: src/suitesparse, uri: 'https://github.com/ethz-asl/suitesparse.git'}
+- git: {local-name: src/glog_catkin, uri: 'https://github.com/ethz-asl/glog_catkin.git'}
+- git: {local-name: src/gflags_catkin, uri: 'https://github.com/ethz-asl/gflags_catkin.git'}
+- git: {local-name: src/catkin_simple, uri: 'https://github.com/ethz-asl/catkin_simple.git'}


### PR DESCRIPTION
Adds additional (brief) instructions for installation using wstool into a pre-existing workspace.

Note the link here https://github.com/skohlbr/cartographer_ros/blame/wstool_install_instructions/README.md#L56 will only start working after a merge.