### PR TITLE
Fix the submap transformation in the RViz plugin.

### DIFF
--- a/cartographer_ros/src/drawable_submap.cc
+++ b/cartographer_ros/src/drawable_submap.cc
@@ -99,7 +99,8 @@ void DrawableSubmap::Update(
   submap_z_ = metadata.pose.position.z;
   metadata_version_ = metadata.submap_version;
   if (texture_version_ != -1) {
-    // We have to update the transform since we already show a texture.
+    // We have to update the transform since we are already displaying a texture
+    // for this submap.
     UpdateTransform();
   }
 }
@@ -144,8 +145,8 @@ void DrawableSubmap::SetAlpha(const double current_tracking_z) {
   const double distance_z = std::abs(submap_z_ - current_tracking_z);
   const double fade_distance =
       std::max(distance_z - kFadeOutStartDistanceInMeters, 0.);
-  const float alpha =
-      (float)std::max(0., 1. - fade_distance / kFadeOutDistanceInMeters);
+  const float alpha = static_cast<float>(
+      std::max(0., 1. - fade_distance / kFadeOutDistanceInMeters));
 
   const Ogre::GpuProgramParametersSharedPtr parameters =
       material_->getTechnique(0)->getPass(0)->getFragmentProgramParameters();
@@ -218,12 +219,12 @@ void DrawableSubmap::UpdateSceneNode() {
 }
 
 void DrawableSubmap::UpdateTransform() {
-  Eigen::Quaterniond quaternion(slice_pose_.rotation());
-  Ogre::Quaternion slice_rotation(quaternion.w(), quaternion.x(),
-                                  quaternion.y(), quaternion.z());
-  Ogre::Vector3 slice_translation(slice_pose_.translation().x(),
-                                  slice_pose_.translation().y(),
-                                  slice_pose_.translation().z());
+  const Eigen::Quaterniond quaternion(slice_pose_.rotation());
+  const Ogre::Quaternion slice_rotation(quaternion.w(), quaternion.x(),
+                                        quaternion.y(), quaternion.z());
+  const Ogre::Vector3 slice_translation(slice_pose_.translation().x(),
+                                        slice_pose_.translation().y(),
+                                        slice_pose_.translation().z());
   scene_node_->setPosition(orientation_ * slice_translation + position_);
   scene_node_->setOrientation(orientation_ * slice_rotation);
 }

--- a/cartographer_ros/src/drawable_submap.cc
+++ b/cartographer_ros/src/drawable_submap.cc
@@ -22,8 +22,6 @@
 #include <cartographer_ros_msgs/SubmapQuery.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <ros/ros.h>
-#include <rviz/display_context.h>
-#include <rviz/frame_manager.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
@@ -38,7 +36,6 @@ namespace rviz {
 namespace {
 
 constexpr std::chrono::milliseconds kMinQueryDelayInMs(250);
-constexpr char kMapFrame[] = "/map";
 constexpr char kSubmapTexturePrefix[] = "SubmapTexture";
 constexpr char kManualObjectPrefix[] = "ManualObjectSubmap";
 constexpr char kSubmapMaterialPrefix[] = "SubmapMaterial";
@@ -87,10 +84,24 @@ DrawableSubmap::~DrawableSubmap() {
 }
 
 void DrawableSubmap::Update(
-    const ::cartographer_ros_msgs::SubmapEntry& metadata) {
+    const ::std_msgs::Header& header,
+    const ::cartographer_ros_msgs::SubmapEntry& metadata,
+    ::rviz::FrameManager* const frame_manager) {
+  Ogre::Vector3 position;
+  Ogre::Quaternion orientation;
+  if (!frame_manager->transform(header, metadata.pose, position, orientation)) {
+    // We don't know where we would display the texture, so we stop here.
+    return;
+  }
   ::cartographer::common::MutexLocker locker(&mutex_);
-  tf::poseMsgToEigen(metadata.pose, submap_pose_);
+  position_ = position;
+  orientation_ = orientation;
+  submap_z_ = metadata.pose.position.z;
   metadata_version_ = metadata.submap_version;
+  if (texture_version_ != -1) {
+    // We have to update the transform since we already show a texture.
+    UpdateTransform();
+  }
 }
 
 bool DrawableSubmap::MaybeFetchTexture(ros::ServiceClient* const client) {
@@ -106,11 +117,6 @@ bool DrawableSubmap::MaybeFetchTexture(ros::ServiceClient* const client) {
   }
   query_in_progress_ = true;
   last_query_timestamp_ = now;
-  QuerySubmap(client);
-  return true;
-}
-
-void DrawableSubmap::QuerySubmap(ros::ServiceClient* const client) {
   rpc_request_future_ = std::async(std::launch::async, [this, client]() {
     ::cartographer_ros_msgs::SubmapQuery srv;
     srv.request.submap_id = submap_id_;
@@ -126,11 +132,24 @@ void DrawableSubmap::QuerySubmap(ros::ServiceClient* const client) {
       query_in_progress_ = false;
     }
   });
+  return true;
 }
 
 bool DrawableSubmap::QueryInProgress() {
   ::cartographer::common::MutexLocker locker(&mutex_);
   return query_in_progress_;
+}
+
+void DrawableSubmap::SetAlpha(const double current_tracking_z) {
+  const double distance_z = std::abs(submap_z_ - current_tracking_z);
+  const double fade_distance =
+      std::max(distance_z - kFadeOutStartDistanceInMeters, 0.);
+  const float alpha =
+      (float)std::max(0., 1. - fade_distance / kFadeOutDistanceInMeters);
+
+  const Ogre::GpuProgramParametersSharedPtr parameters =
+      material_->getTechnique(0)->getPass(0)->getFragmentProgramParameters();
+  parameters->setNamedConstant("u_alpha", UpdateAlpha(alpha));
 }
 
 void DrawableSubmap::UpdateSceneNode() {
@@ -139,9 +158,8 @@ void DrawableSubmap::UpdateSceneNode() {
   std::string compressed_cells(response_.cells.begin(), response_.cells.end());
   std::string cells;
   ::cartographer::common::FastGunzipString(compressed_cells, &cells);
-  Eigen::Affine3d slice_pose;
-  tf::poseMsgToEigen(response_.slice_pose, slice_pose);
-  tf::poseEigenToMsg(submap_pose_ * slice_pose, transformed_pose_);
+  tf::poseMsgToEigen(response_.slice_pose, slice_pose_);
+  UpdateTransform();
   query_in_progress_ = false;
   // The call to Ogre's loadRawData below does not work with an RG texture,
   // therefore we create an RGB one whose blue channel is always 0.
@@ -159,43 +177,20 @@ void DrawableSubmap::UpdateSceneNode() {
   manual_object_->clear();
   const float metric_width = response_.resolution * response_.width;
   const float metric_height = response_.resolution * response_.height;
-
   manual_object_->begin(material_->getName(),
-                        Ogre::RenderOperation::OT_TRIANGLE_LIST);
-  {
-    {
-      // Bottom left
-      manual_object_->position(-metric_height, 0.0f, 0.0f);
-      manual_object_->textureCoord(0.0f, 1.0f);
-      manual_object_->normal(0.0f, 0.0f, 1.0f);
-
-      // Bottom right
-      manual_object_->position(-metric_height, -metric_width, 0.0f);
-      manual_object_->textureCoord(1.0f, 1.0f);
-      manual_object_->normal(0.0f, 0.0f, 1.0f);
-
-      // Top left
-      manual_object_->position(0.0f, 0.0f, 0.0f);
-      manual_object_->textureCoord(0.0f, 0.0f);
-      manual_object_->normal(0.0f, 0.0f, 1.0f);
-
-      // Top left
-      manual_object_->position(0.0f, 0.0f, 0.0f);
-      manual_object_->textureCoord(0.0f, 0.0f);
-      manual_object_->normal(0.0f, 0.0f, 1.0f);
-
-      // Bottom right
-      manual_object_->position(-metric_height, -metric_width, 0.0f);
-      manual_object_->textureCoord(1.0f, 1.0f);
-      manual_object_->normal(0.0f, 0.0f, 1.0f);
-
-      // Top right
-      manual_object_->position(0.0f, -metric_width, 0.0f);
-      manual_object_->textureCoord(1.0f, 0.0f);
-      manual_object_->normal(0.0f, 0.0f, 1.0f);
-    }
-  }
-
+                        Ogre::RenderOperation::OT_TRIANGLE_STRIP);
+  // Bottom left
+  manual_object_->position(-metric_height, 0.0f, 0.0f);
+  manual_object_->textureCoord(0.0f, 1.0f);
+  // Bottom right
+  manual_object_->position(-metric_height, -metric_width, 0.0f);
+  manual_object_->textureCoord(1.0f, 1.0f);
+  // Top left
+  manual_object_->position(0.0f, 0.0f, 0.0f);
+  manual_object_->textureCoord(0.0f, 0.0f);
+  // Top right
+  manual_object_->position(0.0f, -metric_width, 0.0f);
+  manual_object_->textureCoord(1.0f, 0.0f);
   manual_object_->end();
 
   Ogre::DataStreamPtr pixel_stream;
@@ -222,26 +217,15 @@ void DrawableSubmap::UpdateSceneNode() {
   texture_unit->setTextureFiltering(Ogre::TFO_NONE);
 }
 
-void DrawableSubmap::Transform(::rviz::FrameManager* const frame_manager) {
-  Ogre::Vector3 position;
-  Ogre::Quaternion orientation;
-  frame_manager->transform(kMapFrame, ros::Time(0) /* latest */,
-                           transformed_pose_, position, orientation);
-  scene_node_->setPosition(position);
-  scene_node_->setOrientation(orientation);
-}
-
-void DrawableSubmap::SetAlpha(const double current_tracking_z) {
-  const double distance_z =
-      std::abs(submap_pose_.translation().z() - current_tracking_z);
-  const double fade_distance =
-      std::max(distance_z - kFadeOutStartDistanceInMeters, 0.);
-  const float alpha =
-      (float)std::max(0., 1. - fade_distance / kFadeOutDistanceInMeters);
-
-  const Ogre::GpuProgramParametersSharedPtr parameters =
-      material_->getTechnique(0)->getPass(0)->getFragmentProgramParameters();
-  parameters->setNamedConstant("u_alpha", UpdateAlpha(alpha));
+void DrawableSubmap::UpdateTransform() {
+  Eigen::Quaterniond quaternion(slice_pose_.rotation());
+  Ogre::Quaternion slice_rotation(quaternion.w(), quaternion.x(),
+                                  quaternion.y(), quaternion.z());
+  Ogre::Vector3 slice_translation(slice_pose_.translation().x(),
+                                  slice_pose_.translation().y(),
+                                  slice_pose_.translation().z());
+  scene_node_->setPosition(orientation_ * slice_translation + position_);
+  scene_node_->setOrientation(orientation_ * slice_rotation);
 }
 
 float DrawableSubmap::UpdateAlpha(const float target_alpha) {

--- a/cartographer_ros/src/submaps_display.h
+++ b/cartographer_ros/src/submaps_display.h
@@ -17,18 +17,11 @@
 #ifndef CARTOGRAPHER_ROS_GOOGLE_CARTOGRAPHER_SRC_SUBMAPS_DISPLAY_H_
 #define CARTOGRAPHER_ROS_GOOGLE_CARTOGRAPHER_SRC_SUBMAPS_DISPLAY_H_
 
-#include <OgreMaterial.h>
-#include <OgreSceneManager.h>
-#include <OgreSharedPtr.h>
-#include <OgreTexture.h>
-#include <OgreVector3.h>
 #include <cartographer/common/mutex.h>
 #include <cartographer/common/port.h>
 #include <cartographer_ros_msgs/SubmapList.h>
-#include <nav_msgs/MapMetaData.h>
-#include <ros/time.h>
 #include <rviz/message_filter_display.h>
-#include <tf/tfMessage.h>
+#include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>
@@ -60,18 +53,6 @@ class SubmapsDisplay
   void Reset();
 
  private:
-  class SceneManagerListener : public Ogre::SceneManager::Listener {
-   public:
-    SceneManagerListener(std::function<void()> callback)
-        : callback_(callback) {}
-    void preUpdateSceneGraph(Ogre::SceneManager* source, Ogre::Camera* camera) {
-      callback_();
-    }
-
-   private:
-    std::function<void()> callback_;
-  };
-
   void CreateClient();
 
   void onInitialize() override;
@@ -80,9 +61,6 @@ class SubmapsDisplay
       const ::cartographer_ros_msgs::SubmapList::ConstPtr& msg) override;
   void update(float wall_dt, float ros_dt) override;
 
-  void UpdateTransforms();
-
-  SceneManagerListener scene_manager_listener_;
   ::tf2_ros::Buffer tf_buffer_;
   ::tf2_ros::TransformListener tf_listener_;
   ros::ServiceClient client_;


### PR DESCRIPTION
Removes the SceneManagerListener and instead computes the transform
when a new submap list is received. The second part of the transform
is also updated when a new texture is received.

Also simplifies the drawing code a bit by using a triangle strip.