### PR TITLE
Fix a bug using SuiteSparse on Ubuntu 16.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ See https://github.com/googlecartographer/cartographer
 
 ## Installation
 
-Installation has been tested on Ubuntu 14.04 (Trusty) with ROS Indigo. There are multiple options for building cartographer_ros as part of a ROS workspace. Two common use cases are described below.
+Installation has been tested on Ubuntu 14.04 (Trusty) with ROS Indigo and on Ubuntu 16.04 (Xenial) with ROS Kinetic. For ROS Kinetic, simply replace the two occurrences of "indigo" with "kinetic" in the instructions below. There are multiple options for building cartographer_ros as part of a ROS workspace. Two common use cases are described below.
 
 These dependencies always have to be installed:
 
@@ -16,11 +16,10 @@ These dependencies always have to be installed:
       libboost-all-dev \
       liblua5.2-dev \
       libprotobuf-dev \
+      libsuitesparse-dev \
       libwebp-dev \
       protobuf-compiler \
       python-sphinx \
-      libblas-dev \
-      liblapack-dev \
       libpcap-dev  # For 3D SLAM with Velodynes
 
 
@@ -35,11 +34,10 @@ These dependencies always have to be installed:
     # Clone the necessary repos into your Catkin workspace
     git clone https://github.com/googlecartographer/cartographer.git
     git clone https://github.com/googlecartographer/cartographer_ros.git
-    git clone https://github.com/ethz-asl/ceres_catkin.git
-    git clone https://github.com/ethz-asl/suitesparse.git
-    git clone https://github.com/ethz-asl/glog_catkin.git
-    git clone https://github.com/ethz-asl/gflags_catkin.git
-    git clone https://github.com/ethz-asl/catkin_simple.git
+    git clone https://github.com/ethz-asl/ceres_catkin.git  # Caution! Make sure not to have "suitesparse" in you Catkin workspace
+    git clone https://github.com/ethz-asl/glog_catkin.git
+    git clone https://github.com/ethz-asl/gflags_catkin.git
+    git clone https://github.com/ethz-asl/catkin_simple.git
     git clone https://github.com/ros-drivers/velodyne.git  # For 3D SLAM with Velodynes
 
     # Build everything in your Catkin workspace

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ These dependencies always have to be installed:
     # Clone the necessary repos into your Catkin workspace
     git clone https://github.com/googlecartographer/cartographer.git
     git clone https://github.com/googlecartographer/cartographer_ros.git
-    git clone https://github.com/ethz-asl/ceres_catkin.git  # Caution! Make sure not to have "suitesparse" in you Catkin workspace
+    git clone https://github.com/ethz-asl/ceres_catkin.git  # Caution! Make sure you do not have "suitesparse" in you Catkin workspace
     git clone https://github.com/ethz-asl/glog_catkin.git
     git clone https://github.com/ethz-asl/gflags_catkin.git
     git clone https://github.com/ethz-asl/catkin_simple.git

--- a/cartographer_ros.rosinstall
+++ b/cartographer_ros.rosinstall
@@ -1,7 +1,6 @@
 - git: {local-name: src/cartographer, uri: 'https://github.com/googlecartographer/cartographer.git'}
 - git: {local-name: src/cartographer_ros, uri: 'https://github.com/googlecartographer/cartographer_ros.git'}
 - git: {local-name: src/ceres_catkin, uri: 'https://github.com/ethz-asl/ceres_catkin.git'}
-- git: {local-name: src/suitesparse, uri: 'https://github.com/ethz-asl/suitesparse.git'}
 - git: {local-name: src/glog_catkin, uri: 'https://github.com/ethz-asl/glog_catkin.git'}
 - git: {local-name: src/gflags_catkin, uri: 'https://github.com/ethz-asl/gflags_catkin.git'}
 - git: {local-name: src/catkin_simple, uri: 'https://github.com/ethz-asl/catkin_simple.git'}


### PR DESCRIPTION
Using the catkin "suitesparse" and having libsuitesparse-dev installed
leads to builds which crash. This changes the configuration to suggest
using libsuitesparse-dev.