### PR TITLE
Configure the Cartographer node without rosparam.

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -92,7 +92,7 @@ target_link_libraries(cartographer_node
   ${CARTOGRAPHER_LIBRARIES}
   ${catkin_LIBRARIES}
   ${PCL_LIBRARIES}
-  gflags
+  gflags  # TODO(whess): Use or remove gflags_catkin.
 )
 
 add_library(cartographer_rviz_submaps_visualization

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -92,6 +92,7 @@ target_link_libraries(cartographer_node
   ${CARTOGRAPHER_LIBRARIES}
   ${catkin_LIBRARIES}
   ${PCL_LIBRARIES}
+  gflags
 )
 
 add_library(cartographer_rviz_submaps_visualization

--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -18,6 +18,14 @@ include "sparse_pose_graph.lua"
 options = {
   sparse_pose_graph = SPARSE_POSE_GRAPH,
   trajectory_builder = TRAJECTORY_BUILDER,
+  map_frame = "map",
+  odom_frame = "odom",
+  tracking_frame = "base_link",
+  provide_odom = true,
+  laser_min_range_m = 0.,
+  laser_max_range_m = 30.,
+  laser_missing_echo_ray_length_m = 5.,
+  use_multi_echo_2d_laser_scan = true
 }
 
 return options

--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -22,10 +22,10 @@ options = {
   odom_frame = "odom",
   tracking_frame = "base_link",
   provide_odom = true,
-  laser_min_range_m = 0.,
-  laser_max_range_m = 30.,
-  laser_missing_echo_ray_length_m = 5.,
-  use_multi_echo_2d_laser_scan = true
+  laser_min_range = 0.,
+  laser_max_range = 30.,
+  laser_missing_echo_ray_length = 5.,
+  use_multi_echo_laser_scan_2d = true
 }
 
 return options

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -18,6 +18,14 @@ include "sparse_pose_graph.lua"
 options = {
   sparse_pose_graph = SPARSE_POSE_GRAPH,
   trajectory_builder = TRAJECTORY_BUILDER_3D,
+  map_frame = "map",
+  odom_frame = "odom",
+  tracking_frame = "base_link",
+  provide_odom = true,
+  laser_min_range_m = 0.,
+  laser_max_range_m = 30.,
+  laser_missing_echo_ray_length_m = 5.,
+  num_3d_lasers = 2
 }
 
 options.sparse_pose_graph.optimize_every_n_scans = 320

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -22,10 +22,10 @@ options = {
   odom_frame = "odom",
   tracking_frame = "base_link",
   provide_odom = true,
-  laser_min_range_m = 0.,
-  laser_max_range_m = 30.,
-  laser_missing_echo_ray_length_m = 5.,
-  num_3d_lasers = 2
+  laser_min_range = 0.,
+  laser_max_range = 30.,
+  laser_missing_echo_ray_length = 5.,
+  num_lasers_3d = 2
 }
 
 options.sparse_pose_graph.optimize_every_n_scans = 320

--- a/cartographer_ros/configuration_files/turtlebot.lua
+++ b/cartographer_ros/configuration_files/turtlebot.lua
@@ -22,10 +22,10 @@ options = {
   odom_frame = "odom",
   tracking_frame = "base_link",
   provide_odom = false,
-  laser_min_range_m = 0.,
-  laser_max_range_m = 30.,
-  laser_missing_echo_ray_length_m = 5.,
-  use_2d_laser_scan = true
+  laser_min_range = 0.,
+  laser_max_range = 30.,
+  laser_missing_echo_ray_length = 5.,
+  use_laser_scan_2d = true
 }
 
 options.trajectory_builder.expect_imu_data = false

--- a/cartographer_ros/configuration_files/turtlebot.lua
+++ b/cartographer_ros/configuration_files/turtlebot.lua
@@ -18,6 +18,14 @@ include "sparse_pose_graph.lua"
 options = {
   sparse_pose_graph = SPARSE_POSE_GRAPH,
   trajectory_builder = TRAJECTORY_BUILDER,
+  map_frame = "map",
+  odom_frame = "odom",
+  tracking_frame = "base_link",
+  provide_odom = false,
+  laser_min_range_m = 0.,
+  laser_max_range_m = 30.,
+  laser_missing_echo_ray_length_m = 5.,
+  use_2d_laser_scan = true
 }
 
 options.trajectory_builder.expect_imu_data = false

--- a/cartographer_ros/launch/backpack_2d.launch
+++ b/cartographer_ros/launch/backpack_2d.launch
@@ -26,7 +26,7 @@
           -configuration_directory $(find cartographer_ros)/configuration_files
           -configuration_basename backpack_2d.lua"
       output="screen" >
-    <remap from="echoes" to="horizontal_2d_laser" />
+    <remap from="echoes" to="horizontal_laser_2d" />
   </node>
 
 </launch>

--- a/cartographer_ros/launch/backpack_2d.launch
+++ b/cartographer_ros/launch/backpack_2d.launch
@@ -22,22 +22,11 @@
     type="robot_state_publisher" />
 
   <node name="cartographer" pkg="cartographer_ros"
-      type="cartographer_node" output="screen" >
-    <rosparam subst_value="true">
-      map_frame: "map"
-      odom_frame: "odom"
-      tracking_frame: "base_link"
-      provide_odom: true
-      configuration_files_directories: [
-        "$(find cartographer_ros)/configuration_files"
-      ]
-      mapping_configuration_basename: "backpack_2d.lua"
-      imu_topic: "/imu"
-      multi_echo_laser_scan_2d_topic: "/horizontal_2d_laser"
-      laser_min_range_m: 0.
-      laser_max_range_m: 30.
-      laser_missing_echo_ray_length_m: 5.
-    </rosparam>
+      type="cartographer_node" args="
+          -configuration_directory $(find cartographer_ros)/configuration_files
+          -configuration_basename backpack_2d.lua"
+      output="screen" >
+    <remap from="echoes" to="horizontal_2d_laser" />
   </node>
 
 </launch>

--- a/cartographer_ros/launch/backpack_3d.launch
+++ b/cartographer_ros/launch/backpack_3d.launch
@@ -22,22 +22,12 @@
     type="robot_state_publisher" />
 
   <node name="cartographer" pkg="cartographer_ros"
-      type="cartographer_node" output="screen" >
-    <rosparam subst_value="true">
-      map_frame: "map"
-      odom_frame: "odom"
-      tracking_frame: "base_link"
-      provide_odom: true
-      configuration_files_directories: [
-        "$(find cartographer_ros)/configuration_files"
-      ]
-      mapping_configuration_basename: "backpack_3d.lua"
-      imu_topic: "/imu"
-      laser_scan_3d_topics: ["/horizontal_3d_laser", "/vertical_3d_laser"]
-      laser_min_range_m: 0.
-      laser_max_range_m: 30.
-      laser_missing_echo_ray_length_m: 5.
-    </rosparam>
+      type="cartographer_node" args="
+          -configuration_directory $(find cartographer_ros)/configuration_files
+          -configuration_basename backpack_3d.lua"
+      output="screen" >
+    <remap from="points2_1" to="horizontal_3d_laser" />
+    <remap from="points2_2" to="vertical_3d_laser" />
   </node>
 
 </launch>

--- a/cartographer_ros/launch/backpack_3d.launch
+++ b/cartographer_ros/launch/backpack_3d.launch
@@ -26,8 +26,8 @@
           -configuration_directory $(find cartographer_ros)/configuration_files
           -configuration_basename backpack_3d.lua"
       output="screen" >
-    <remap from="points2_1" to="horizontal_3d_laser" />
-    <remap from="points2_2" to="vertical_3d_laser" />
+    <remap from="points2_1" to="horizontal_laser_3d" />
+    <remap from="points2_2" to="vertical_laser_3d" />
   </node>
 
 </launch>

--- a/cartographer_ros/launch/turtlebot.launch
+++ b/cartographer_ros/launch/turtlebot.launch
@@ -22,22 +22,11 @@
     type="robot_state_publisher" />
 
   <node name="cartographer" pkg="cartographer_ros"
-      type="cartographer_node" output="screen" >
-    <rosparam subst_value="true">
-      map_frame: "map"
-      odom_frame: "odom"
-      tracking_frame: "base_link"
-      provide_odom: false
-      configuration_files_directories: [
-        "$(find cartographer_ros)/configuration_files"
-      ]
-      mapping_configuration_basename: "turtlebot.lua"
-      imu_topic: "/imu"
-      laser_scan_2d_topic: "/horizontal_2d_laser"
-      laser_min_range_m: 0.
-      laser_max_range_m: 30.
-      laser_missing_echo_ray_length_m: 5.
-    </rosparam>
+      type="cartographer_node" args="
+          -configuration_directory $(find cartographer_ros)/configuration_files
+          -configuration_basename turtlebot.lua"
+      output="screen" >
+    <remap from="scan" to="horizontal_2d_laser" />
   </node>
 
 </launch>

--- a/cartographer_ros/launch/turtlebot.launch
+++ b/cartographer_ros/launch/turtlebot.launch
@@ -26,7 +26,7 @@
           -configuration_directory $(find cartographer_ros)/configuration_files
           -configuration_basename turtlebot.lua"
       output="screen" >
-    <remap from="scan" to="horizontal_2d_laser" />
+    <remap from="scan" to="horizontal_laser_2d" />
   </node>
 
 </launch>


### PR DESCRIPTION
Configuration of Cartographer's ROS integration is now
entirely handled by Lua. The path and basename of the
configuration are given by command line flags.
The node is listening to default topic names which are
expected to be remapped as needed.