### PR TITLE
Remap in the launch file was the wrong way around

### DIFF
--- a/cartographer_ros/launch/turtlebot.launch
+++ b/cartographer_ros/launch/turtlebot.launch
@@ -26,7 +26,7 @@
           -configuration_directory $(find cartographer_ros)/configuration_files
           -configuration_basename turtlebot.lua"
       output="screen" >
-    <remap from="scan" to="horizontal_laser_2d" />
+    <remap from="horizontal_laser_2d" to="scan" />
   </node>
 
 </launch>


### PR DESCRIPTION
Remapping are based only on topic names, not whether you publish or subscribe.

So now we replace any call to topic `horizontal_laser_2d` with topic `scan`, instead of the other way around.