### PR TITLE
Cmakelist fixes

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -95,6 +95,10 @@ target_link_libraries(cartographer_node
   gflags  # TODO(whess): Use or remove gflags_catkin.
 )
 
+add_dependencies(cartographer_node
+  ${catkin_EXPORTED_TARGETS}
+)
+
 add_library(cartographer_rviz_submaps_visualization
   src/drawable_submap.cc
   src/drawable_submap.h
@@ -110,6 +114,10 @@ target_link_libraries(cartographer_rviz_submaps_visualization
   ${ZLIB_LIBRARIES}
 )
 
+add_dependencies(cartographer_rviz_submaps_visualization
+  ${catkin_EXPORTED_TARGETS}
+)
+
 add_executable(time_conversion_test
   src/time_conversion_test.cc
   src/time_conversion.h
@@ -120,6 +128,10 @@ target_link_libraries(time_conversion_test
   ${GTEST_BOTH_LIBRARIES}
   ${CARTOGRAPHER_LIBRARIES}
   ${catkin_LIBRARIES}
+)
+
+add_dependencies(time_conversion_test
+  ${catkin_EXPORTED_TARGETS}
 )
 
 add_test(time_conversion_test time_conversion_test)
@@ -137,17 +149,21 @@ install(DIRECTORY configuration_files/
 )
 
 install(TARGETS
-  cartographer_rviz_submaps_visualization
+  cartographer_rviz_submaps_visualization cartographer_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 install(FILES
-  plugin_description.xml
+  rviz_plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
 install(DIRECTORY ogre_media/
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/ogre_media}
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/ogre_media
 )
+
+install(PROGRAMS
+         scripts/imu_pub.py
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/cartographer_ros/scripts/imu_pub.py
+++ b/cartographer_ros/scripts/imu_pub.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import rospy
+from sensor_msgs.msg import Imu
+
+
+class PublishImu(object):  # pylint: disable=too-few-public-methods
+    """
+    Class that transforms a message and republishes it with a new timestamp
+    """
+    def __init__(self, topic):
+        self._pub = rospy.Publisher(topic,
+                                    Imu,
+                                    queue_size=1)
+        self.ctrl_rate = rospy.Rate(10)
+
+    def start(self):
+        """
+        publishing data
+        """
+        msg = Imu()
+        msg.header.frame_id = "base_link"
+        while not rospy.is_shutdown():
+            msg.header.stamp = rospy.Time.now()
+            self._pub.publish(msg)
+            self.ctrl_rate.sleep()
+
+if __name__ == '__main__':
+    rospy.init_node('imu_publisher')
+    rospy.loginfo("Initialized")
+    imupub = PublishImu("/imu")
+    imupub.start()
+    rospy.loginfo("Bye Bye")


### PR DESCRIPTION
Some minor problems were found in the CMakeLists.txt that prohibited installing the node.

First of all, the EXPORTED_TARGETS were added as dependency, following the ros-indigo specification: 
http://docs.ros.org/indigo/api/catkin/html/howto/format1/cpp_msg_dependencies.html
This leads to the messages being built before the code itself.

Secondly, cartographer_node was added as a target, in order to make the program executable using launch files.

Thirdly, the plugin_description.xml was renamed to rviz_plugin_description.xml.
This is required to install the correct file.

Lastly, a typo was fixed where an extra "}" seemed to be dangling at the end of a line.

