### PR TITLE
Adds lua parameter for setting transform wait time

### DIFF
--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -26,6 +26,7 @@ options = {
   laser_min_range = 0.,
   laser_max_range = 30.,
   laser_missing_echo_ray_length = 5.,
+  transform_wait_time = 0.01,
   use_multi_echo_laser_scan_2d = true
 }
 

--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -26,7 +26,7 @@ options = {
   laser_min_range = 0.,
   laser_max_range = 30.,
   laser_missing_echo_ray_length = 5.,
-  transform_wait_time = 0.01,
+  lookup_transform_timeout = 0.01,
   use_multi_echo_laser_scan_2d = true
 }
 

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -26,6 +26,7 @@ options = {
   laser_min_range = 0.,
   laser_max_range = 30.,
   laser_missing_echo_ray_length = 5.,
+  transform_wait_time = 0.01,
   num_lasers_3d = 2
 }
 

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -26,7 +26,7 @@ options = {
   laser_min_range = 0.,
   laser_max_range = 30.,
   laser_missing_echo_ray_length = 5.,
-  transform_wait_time = 0.01,
+  lookup_transform_timeout = 0.01,
   num_lasers_3d = 2
 }
 

--- a/cartographer_ros/configuration_files/turtlebot.lua
+++ b/cartographer_ros/configuration_files/turtlebot.lua
@@ -26,6 +26,7 @@ options = {
   laser_min_range = 0.,
   laser_max_range = 30.,
   laser_missing_echo_ray_length = 5.,
+  transform_wait_time = 0.01,
   use_laser_scan_2d = true
 }
 

--- a/cartographer_ros/configuration_files/turtlebot.lua
+++ b/cartographer_ros/configuration_files/turtlebot.lua
@@ -26,7 +26,7 @@ options = {
   laser_min_range = 0.,
   laser_max_range = 30.,
   laser_missing_echo_ray_length = 5.,
-  transform_wait_time = 0.01,
+  lookup_transform_timeout = 0.01,
   use_laser_scan_2d = true
 }
 

--- a/cartographer_ros/src/cartographer_node_main.cc
+++ b/cartographer_ros/src/cartographer_node_main.cc
@@ -94,7 +94,6 @@ constexpr int64 kTrajectoryId = 0;
 constexpr int kSubscriberQueueSize = 150;
 constexpr int kSubmapPublishPeriodInUts = 300 * 10000ll;  // 300 milliseconds
 constexpr int kPosePublishPeriodInUts = 5 * 10000ll;      // 5 milliseconds
-constexpr double kMaxTransformDelaySeconds = 0.01;
 constexpr double kSensorDataRatesLoggingPeriodSeconds = 15.;
 
 // Unique default topic names. Expected to be remapped as needed.
@@ -248,6 +247,7 @@ class Node {
   double laser_min_range_;
   double laser_max_range_;
   double laser_missing_echo_ray_length_;
+  double transform_wait_time_;
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_;
@@ -282,7 +282,7 @@ Rigid3d Node::LookupToTrackingTransformOrThrow(const carto::common::Time time,
                                                const string& frame_id) {
   return ToRigid3d(
       tf_buffer_.lookupTransform(tracking_frame_, frame_id, ToRos(time),
-                                 ros::Duration(kMaxTransformDelaySeconds)));
+                                 ros::Duration(transform_wait_time_)));
 }
 
 void Node::OdometryMessageCallback(const nav_msgs::Odometry::ConstPtr& msg) {
@@ -416,6 +416,8 @@ void Node::Initialize() {
   laser_max_range_ = lua_parameter_dictionary.GetDouble("laser_max_range");
   laser_missing_echo_ray_length_ =
       lua_parameter_dictionary.GetDouble("laser_missing_echo_ray_length");
+  transform_wait_time_ =
+      lua_parameter_dictionary.GetDouble("transform_wait_time");
 
   // Set of all topics we subscribe to. We use the non-remapped default names
   // which are unique.

--- a/cartographer_ros/src/cartographer_node_main.cc
+++ b/cartographer_ros/src/cartographer_node_main.cc
@@ -247,7 +247,7 @@ class Node {
   double laser_min_range_;
   double laser_max_range_;
   double laser_missing_echo_ray_length_;
-  double transform_wait_time_;
+  double lookup_transform_timeout_;
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_;
@@ -282,7 +282,7 @@ Rigid3d Node::LookupToTrackingTransformOrThrow(const carto::common::Time time,
                                                const string& frame_id) {
   return ToRigid3d(
       tf_buffer_.lookupTransform(tracking_frame_, frame_id, ToRos(time),
-                                 ros::Duration(transform_wait_time_)));
+                                 ros::Duration(lookup_transform_timeout_)));
 }
 
 void Node::OdometryMessageCallback(const nav_msgs::Odometry::ConstPtr& msg) {
@@ -416,8 +416,8 @@ void Node::Initialize() {
   laser_max_range_ = lua_parameter_dictionary.GetDouble("laser_max_range");
   laser_missing_echo_ray_length_ =
       lua_parameter_dictionary.GetDouble("laser_missing_echo_ray_length");
-  transform_wait_time_ =
-      lua_parameter_dictionary.GetDouble("transform_wait_time");
+  lookup_transform_timeout_ =
+      lua_parameter_dictionary.GetDouble("lookup_transform_timeout");
 
   // Set of all topics we subscribe to. We use the non-remapped default names
   // which are unique.


### PR DESCRIPTION
Fixes #32 by allowing user to specify tf lookup wait time via the `transform_wait_time` lua parameter. Adjusted the existing config files accordingly.