### PR TITLE
Adds Catkin wrapper for building Ceres.

### DIFF
--- a/ceres_solver/CMakeLists.txt
+++ b/ceres_solver/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2016 The Cartographer Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8.7)
+
+project(ceres_solver)
+
+include(ExternalProject)
+set(TAG 6a13e39e8171f450fbb89188d97f198def81937e) # Version 1.11
+ExternalProject_Add(ceres_src
+  GIT_REPOSITORY https://ceres-solver.googlesource.com/ceres-solver
+  GIT_TAG ${TAG}
+  CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+      -DBUILD_EXAMPLES=OFF
+      -DBUILD_TESTING=OFF
+)
+
+# Ceres is installed via the ExternalProject_Add command above. However, we
+# must provide this no-op install target to satisfy Catkin.
+install(CODE "")

--- a/ceres_solver/package.xml
+++ b/ceres_solver/package.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!--
   Copyright 2016 The Cartographer Authors
 
@@ -14,26 +15,25 @@
   limitations under the License.
 -->
 
-<package>
+<package format="2">
   <name>ceres_solver</name>
   <version>1.11.0</version>
   <description>ceres_solver</description>
-  <maintainer email="google-cartographer@googlegroups.com">Google Inc.</maintainer>
+  <maintainer email="google-cartographer@googlegroups.com">
+    The Cartographer Authors
+  </maintainer>
   <license>New BSD</license>
   <url type="website">http://ceres-solver.org/</url>
-  <author>Google Inc.</author>
 
-  <run_depend>catkin</run_depend>
+  <buildtool_depend>catkin</buildtool_depend>
 
-  <buildtool_depend>cmake</buildtool_depend>
-
-  <build_depend>atlas</build_depend>
-  <build_depend>libblas-dev</build_depend>
-  <build_depend>eigen</build_depend>
-  <build_depend>gfortran</build_depend>
-  <build_depend>libgflags-dev</build_depend>
-  <build_depend>libgoogle-glog-dev</build_depend>
-  <build_depend>suitesparse</build_depend>
+  <depend>atlas</build_depend>
+  <depend>libblas-dev</build_depend>
+  <depend>eigen</build_depend>
+  <depend>gfortran</build_depend>
+  <depend>libgflags-dev</build_depend>
+  <depend>libgoogle-glog-dev</build_depend>
+  <depend>suitesparse</build_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/ceres_solver/package.xml
+++ b/ceres_solver/package.xml
@@ -27,13 +27,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>atlas</build_depend>
-  <depend>libblas-dev</build_depend>
-  <depend>eigen</build_depend>
-  <depend>gfortran</build_depend>
-  <depend>libgflags-dev</build_depend>
-  <depend>libgoogle-glog-dev</build_depend>
-  <depend>suitesparse</build_depend>
+  <depend>atlas</depend>
+  <depend>libblas-dev</depend>
+  <depend>eigen</depend>
+  <depend>gfortran</depend>
+  <depend>libgflags-dev</depend>
+  <depend>libgoogle-glog-dev</depend>
+  <depend>suitesparse</depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/ceres_solver/package.xml
+++ b/ceres_solver/package.xml
@@ -1,0 +1,41 @@
+<!--
+  Copyright 2016 The Cartographer Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<package>
+  <name>ceres_solver</name>
+  <version>1.11.0</version>
+  <description>ceres_solver</description>
+  <maintainer email="google-cartographer@googlegroups.com">Google Inc.</maintainer>
+  <license>New BSD</license>
+  <url type="website">http://ceres-solver.org/</url>
+  <author>Google Inc.</author>
+
+  <run_depend>catkin</run_depend>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <build_depend>atlas</build_depend>
+  <build_depend>libblas-dev</build_depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>gfortran</build_depend>
+  <build_depend>libgflags-dev</build_depend>
+  <build_depend>libgoogle-glog-dev</build_depend>
+  <build_depend>suitesparse</build_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This wrapper is made to be much simpler than the one provided at https://github.com/ethz-asl/ceres_catkin by relying on the system installed libraries for glog, gflags, and suitesparse. Additionally, we do not patch Ceres in any way.