### PR TITLE
Disable culling for submaps and reduce overdraw.

### DIFF
--- a/cartographer_rviz/src/drawable_submap.cc
+++ b/cartographer_rviz/src/drawable_submap.cc
@@ -67,6 +67,8 @@ DrawableSubmap::DrawableSubmap(const int submap_id, const int trajectory_id,
                                GetSubmapIdentifier(trajectory_id_, submap_id));
   material_->setReceiveShadows(false);
   material_->getTechnique(0)->setLightingEnabled(false);
+  material_->setCullingMode(Ogre::CULL_NONE);
+  material_->setDepthBias(-1.f, 0.f);
   material_->setDepthWriteEnabled(false);
   scene_node_->attachObject(manual_object_);
   connect(this, SIGNAL(RequestSucceeded()), this, SLOT(UpdateSceneNode()));


### PR DESCRIPTION
We disable backface culling so that submaps also show when looked at from
below.

We add a depth bias to move submaps further to the back, so that submaps
do not overdraw the visualization of laser scans which makes the latter
sometimes hard to see.