### PR TITLE
[feature] Use pose covariance from odometry message

### DIFF
--- a/cartographer_ros/cartographer_ros/sensor_bridge.cc
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.cc
@@ -57,18 +57,9 @@ SensorBridge::SensorBridge(
 void SensorBridge::HandleOdometryMessage(
     const string& topic, const nav_msgs::Odometry::ConstPtr& msg) {
   const carto::common::Time time = FromRos(msg->header.stamp);
-  const Eigen::Matrix3d translational =
-      Eigen::Matrix3d::Identity() *
-      options_.constant_odometry_translational_variance;
-  const Eigen::Matrix3d rotational =
-      Eigen::Matrix3d::Identity() *
-      options_.constant_odometry_rotational_variance;
-  // clang-format off
-  carto::kalman_filter::PoseCovariance covariance;
-  covariance <<
-      translational, Eigen::Matrix3d::Zero(),
-      Eigen::Matrix3d::Zero(), rotational;
-  // clang-format on
+  const carto::kalman_filter::PoseCovariance covariance =
+      Eigen::Map<const carto::kalman_filter::PoseCovariance>(
+          msg->pose.covariance.data());
   const auto sensor_to_tracking =
       tf_bridge_->LookupToTracking(time, msg->child_frame_id);
   if (sensor_to_tracking != nullptr) {

--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -20,8 +20,6 @@ options = {
     horizontal_laser_min_range = 0.,
     horizontal_laser_max_range = 30.,
     horizontal_laser_missing_echo_ray_length = 5.,
-    constant_odometry_translational_variance = 0.,
-    constant_odometry_rotational_variance = 0.,
   },
   map_frame = "map",
   tracking_frame = "base_link",

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -20,8 +20,6 @@ options = {
     horizontal_laser_min_range = 0.,
     horizontal_laser_max_range = 30.,
     horizontal_laser_missing_echo_ray_length = 5.,
-    constant_odometry_translational_variance = 0.,
-    constant_odometry_rotational_variance = 0.,
   },
   map_frame = "map",
   tracking_frame = "base_link",

--- a/cartographer_ros/configuration_files/pr2.lua
+++ b/cartographer_ros/configuration_files/pr2.lua
@@ -20,8 +20,6 @@ options = {
     horizontal_laser_min_range = 0.,
     horizontal_laser_max_range = 30.,
     horizontal_laser_missing_echo_ray_length = 5.,
-    constant_odometry_translational_variance = 0.,
-    constant_odometry_rotational_variance = 0.,
   },
   map_frame = "map",
   tracking_frame = "base_footprint",

--- a/cartographer_ros/configuration_files/revo_lds.lua
+++ b/cartographer_ros/configuration_files/revo_lds.lua
@@ -20,8 +20,6 @@ options = {
     horizontal_laser_min_range = 0.3,
     horizontal_laser_max_range = 8.,
     horizontal_laser_missing_echo_ray_length = 1.,
-    constant_odometry_translational_variance = 0.,
-    constant_odometry_rotational_variance = 0.,
   },
   map_frame = "map",
   tracking_frame = "horizontal_laser_link",

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -55,12 +55,6 @@ use_odometry_data
   If enabled, subscribes to `nav_msgs/Odometry`_ on the topic "odom". Odometry
   must be provided in this case, and the information will be included in SLAM.
 
-sensor_bridge.constant_odometry_translational_variance
-  The variance to use for the translational component of odometry.
-
-sensor_bridge.constant_odometry_rotational_variance
-  The variance to use for the rotational component of odometry.
-
 use_horizontal_laser
   If enabled, the node subscribes to `sensor_msgs/LaserScan`_ on the "scan"
   topic. If 2D SLAM is used, either this or *use_horizontal_multi_echo_laser*


### PR DESCRIPTION
To me, it's more practical and consistent to directly use the pose covariance within the nav_msgs/Odometry message.