### PR TITLE
[feature] Use covariances from odometry msgs

### DIFF
--- a/cartographer_ros/cartographer_ros/sensor_bridge.h
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.h
@@ -37,8 +37,6 @@ struct SensorBridgeOptions {
   double horizontal_laser_min_range;
   double horizontal_laser_max_range;
   double horizontal_laser_missing_echo_ray_length;
-  double constant_odometry_translational_variance;
-  double constant_odometry_rotational_variance;
 };
 
 SensorBridgeOptions CreateSensorBridgeOptions(

--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -20,8 +20,6 @@ options = {
     horizontal_laser_min_range = 0.,
     horizontal_laser_max_range = 30.,
     horizontal_laser_missing_echo_ray_length = 5.,
-    constant_odometry_translational_variance = 0.,
-    constant_odometry_rotational_variance = 0.,
   },
   map_frame = "map",
   tracking_frame = "base_link",

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -20,8 +20,6 @@ options = {
     horizontal_laser_min_range = 0.,
     horizontal_laser_max_range = 30.,
     horizontal_laser_missing_echo_ray_length = 5.,
-    constant_odometry_translational_variance = 0.,
-    constant_odometry_rotational_variance = 0.,
   },
   map_frame = "map",
   tracking_frame = "base_link",

--- a/cartographer_ros/configuration_files/pr2.lua
+++ b/cartographer_ros/configuration_files/pr2.lua
@@ -20,8 +20,6 @@ options = {
     horizontal_laser_min_range = 0.,
     horizontal_laser_max_range = 30.,
     horizontal_laser_missing_echo_ray_length = 5.,
-    constant_odometry_translational_variance = 0.,
-    constant_odometry_rotational_variance = 0.,
   },
   map_frame = "map",
   tracking_frame = "base_footprint",

--- a/cartographer_ros/configuration_files/revo_lds.lua
+++ b/cartographer_ros/configuration_files/revo_lds.lua
@@ -20,8 +20,6 @@ options = {
     horizontal_laser_min_range = 0.3,
     horizontal_laser_max_range = 8.,
     horizontal_laser_missing_echo_ray_length = 1.,
-    constant_odometry_translational_variance = 0.,
-    constant_odometry_rotational_variance = 0.,
   },
   map_frame = "map",
   tracking_frame = "horizontal_laser_link",

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -55,12 +55,6 @@ use_odometry_data
   If enabled, subscribes to `nav_msgs/Odometry`_ on the topic "odom". Odometry
   must be provided in this case, and the information will be included in SLAM.
 
-sensor_bridge.constant_odometry_translational_variance
-  The variance to use for the translational component of odometry.
-
-sensor_bridge.constant_odometry_rotational_variance
-  The variance to use for the rotational component of odometry.
-
 use_horizontal_laser
   If enabled, the node subscribes to `sensor_msgs/LaserScan`_ on the "scan"
   topic. If 2D SLAM is used, either this or *use_horizontal_multi_echo_laser*


### PR DESCRIPTION
To me it's more consistent to directly use pose covariances from nav_msgs/Odometry messages.