### PR TITLE
Write PCD file for 3D runs when finalizing a trajectory.

### DIFF
--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -95,6 +95,14 @@ google_library(xray
     xray.h
 )
 
+google_library(pcd
+  USES_CARTOGRAPHER
+  SRCS
+    pcd.cc
+  HDRS
+    pcd.h
+)
+
 google_catkin_test(time_conversion_test
   USES_CARTOGRAPHER
   USES_ROS
@@ -122,6 +130,7 @@ google_binary(cartographer_node
     tf_bridge
     time_conversion
     xray
+    pcd
 )
 
 install(TARGETS cartographer_node

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -56,6 +56,7 @@
 #include "cartographer_ros/tf_bridge.h"
 #include "cartographer_ros/time_conversion.h"
 #include "cartographer_ros/xray.h"
+#include "cartographer_ros/pcd.h"
 #include "cartographer_ros_msgs/FinishTrajectory.h"
 #include "cartographer_ros_msgs/SubmapEntry.h"
 #include "cartographer_ros_msgs/SubmapList.h"
@@ -379,6 +380,11 @@ bool Node::HandleFinishTrajectory(
 
   if (options_.map_builder_options.use_trajectory_builder_3d()) {
     WriteXRayImages(trajectory_nodes,
+                    options_.map_builder_options.trajectory_builder_3d_options()
+                        .submaps_options()
+                        .high_resolution(),
+                    request.stem);
+    WritePCDFile(trajectory_nodes,
                     options_.map_builder_options.trajectory_builder_3d_options()
                         .submaps_options()
                         .high_resolution(),

--- a/cartographer_ros/cartographer_ros/pcd.cc
+++ b/cartographer_ros/cartographer_ros/pcd.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cartographer_ros/pcd.h"
+
+#include "cartographer/io/null_points_processor.h"
+#include "cartographer/io/points_processor.h"
+#include "cartographer/io/pcd_points_processor.h"
+
+#include <iostream>
+#include <fstream>
+
+
+namespace cartographer_ros {
+
+namespace carto = ::cartographer;
+
+void WritePCDFile(const std::vector<::cartographer::mapping::TrajectoryNode>&
+                         trajectory_nodes,
+                     const double voxel_size, const std::string& stem) {
+  carto::io::NullPointsProcessor null_points_processor;
+  carto::io::PCDPointsProcessor pc_point_processor(
+      voxel_size,
+      stem + "_pointcloud.pcd", &null_points_processor);
+
+  for (const auto& node : trajectory_nodes) {
+    const carto::sensor::LaserFan laser_fan = carto::sensor::TransformLaserFan(
+        carto::sensor::Decompress(node.constant_data->laser_fan_3d),
+        node.pose.cast<float>());
+
+    carto::io::PointsBatch points_batch;
+    points_batch.origin = laser_fan.origin;
+    points_batch.points = laser_fan.returns;
+    pc_point_processor.Process(points_batch);
+  }
+  pc_point_processor.Flush();
+}
+
+}  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/pcd.h
+++ b/cartographer_ros/cartographer_ros/pcd.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CARTOGRAPHER_ROS_PCD_H_
+#define CARTOGRAPHER_ROS_PCD_H_
+
+#include <string>
+#include <vector>
+
+#include "cartographer/mapping/trajectory_node.h"
+
+namespace cartographer_ros {
+
+// Writes PCD file from the 'trajectory_nodes'. The filenames will all start
+// with 'stem'.
+void WritePCDFile(const std::vector<::cartographer::mapping::TrajectoryNode>&
+                         trajectory_nodes,
+                     double voxel_size, const std::string& stem);
+
+}  // namespace cartographer_ros
+
+#endif  // CARTOGRAPHER_ROS_PCD_H_


### PR DESCRIPTION
This commit depends on [PR #79 on cartographer](https://github.com/googlecartographer/cartographer/pull/79).

Now, it outputs both of XRay image and PCD.
It would be better to be selectable which method of output to be used through a node parameter or the service call. 