### PR TITLE
Set map->odom transform timestamp to ros::Time::now() to prevent wait issue

### DIFF
--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -402,7 +402,7 @@ void Node::PublishPoseAndScanMatchedPointCloud(
   const Rigid3d tracking_to_map = local_to_map * tracking_to_local;
 
   geometry_msgs::TransformStamped stamped_transform;
-  stamped_transform.header.stamp = ToRos(last_pose_estimate.time);
+  stamped_transform.header.stamp = ros::Time::now();
 
   const auto published_to_tracking = tf_bridge_.LookupToTracking(
       last_pose_estimate.time, options_.published_frame);


### PR DESCRIPTION
As briefly mentioned in #47, not updating the timestamp of the map->odom transform published at fixed rate results in components always waiting till a new SLAM pose estimate is produced. For robots performing online mapping and navigation this clearly can be undesirable (at least when using tools such as ROS navigation or rviz). 

To demonstrate, here is a video of running the demo bag file from https://github.com/tu-darmstadt-ros-pkg/cartographer_hector_tracker before the change:
[![Alt text](https://img.youtube.com/vi/Ltq_PF4DmOA/0.jpg)](https://www.youtube.com/watch?v=Ltq_PF4DmOA)
As visible, the robot "jumps" every few seconds as only at these snapshots valid transform data to the world frame is available.

After the change in this PR the robot moves smoothly:
[![Alt text](https://img.youtube.com/vi/Dn6ybWnW77M/0.jpg)](https://www.youtube.com/watch?v=Dn6ybWnW77M)

Putting this out here for discussion, perhaps how things are stamped should be configurable.
