### PR TITLE
Fixes urdfdom_headers version compatibility

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -53,6 +53,13 @@ find_package(PCL REQUIRED COMPONENTS common io)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system iostreams)
 
+find_package(urdfdom_headers REQUIRED)
+if(DEFINED urdfdom_headers_VERSION)
+  if(${urdfdom_headers_VERSION} GREATER 0.4.1)
+    add_definitions(-DURDFDOM_HEADERS_HAS_SHARED_PTR_DEFS)
+  endif()
+endif()
+
 add_subdirectory("cartographer_ros")
 
 install(DIRECTORY launch urdf configuration_files

--- a/cartographer_ros/cartographer_ros/assets_writer_main.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer_main.cc
@@ -69,7 +69,7 @@ void ReadStaticTransformsFromUrdf(const string& urdf_filename,
                                   ::tf2_ros::Buffer* const buffer) {
   urdf::Model model;
   CHECK(model.initFile(urdf_filename));
-  std::vector<boost::shared_ptr<urdf::Link>> links;
+  std::vector<urdf::LinkSharedPtr> links;
   model.getLinks(links);
   for (const auto& link : links) {
     if (!link->getParent() || link->parent_joint->type != urdf::Joint::FIXED) {

--- a/cartographer_ros/cartographer_ros/assets_writer_main.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer_main.cc
@@ -69,7 +69,11 @@ void ReadStaticTransformsFromUrdf(const string& urdf_filename,
                                   ::tf2_ros::Buffer* const buffer) {
   urdf::Model model;
   CHECK(model.initFile(urdf_filename));
+#if URDFDOM_HEADERS_HAS_SHARED_PTR_DEFS
   std::vector<urdf::LinkSharedPtr> links;
+#else
+  std::vector<boost::shared_ptr<urdf::Link>> links;
+#endif
   model.getLinks(links);
   for (const auto& link : links) {
     if (!link->getParent() || link->parent_joint->type != urdf::Joint::FIXED) {


### PR DESCRIPTION
On latest urdfdom, urdf::LinkSharedPtr uses C++11's std::shared_ptr instead of boost::shared_ptr.