### PR TITLE
Unbreak cartographer_turtlebot and cartographer_toyota_hsr.

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.3)
 
 project(cartographer_ros)
 
@@ -64,7 +64,6 @@ catkin_package(
   CATKIN_DEPENDS
     ${PACKAGE_DEPENDENCIES}
   DEPENDS
-    CARTOGRAPHER
     YAMLCPP
     PCL
     EIGEN3


### PR DESCRIPTION
FindThreads.cmake (e.g. of trusty) is used which adds the
"-lpthead" dependency that is added to cartographer's
dependencies. Catkin then fails to resolve this in the
cartographer_rosConfig.cmake file it generates to be used
by all dependencies of cartographer_ros.

This means for now, users of cartographer_ros also have to
directly depend on cartographer.