### PR TITLE
Sphinx build fix

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -18,8 +18,8 @@ project(cartographer_ros_docs)
 
 find_package(Sphinx)
 if(SPHINX_FOUND)
-  set(OUTPUT_DIR "${CMAKE_BINARY_DIR}/docs/html")
-  add_custom_target(build_doc ALL
+  set(OUTPUT_DIR "${PROJECT_BINARY_DIR}/docs/html")
+  add_custom_target(build_doc_ros ALL
       ${SPHINX_EXECUTABLE} -b html
       ${CMAKE_CURRENT_SOURCE_DIR}/source
       ${CMAKE_CURRENT_BINARY_DIR}/html


### PR DESCRIPTION
This was missed in #262. The "build_doc" target has also been renamed to
"build_doc_ros" in order to avoid conflict with the "build_doc" target
in libcartographer, in case both are being built in the same CMake
project.