### PR TITLE
Change SubmapEntry submap_version field to be int32

### DIFF
--- a/cartographer_ros_msgs/msg/SubmapEntry.msg
+++ b/cartographer_ros_msgs/msg/SubmapEntry.msg
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-uint32 submap_version
+int32 submap_version
 geometry_msgs/Pose pose


### PR DESCRIPTION
This matches the specification in SubmapQuery.srv and Cartographer API,
and resolves a misc IDE warning about unsigned/signed assignment.