### PR TITLE
Added reading intensity values from point clouds

### DIFF
--- a/cartographer_ros/cartographer_ros/msg_conversion.cc
+++ b/cartographer_ros/cartographer_ros/msg_conversion.cc
@@ -154,10 +154,10 @@ PointCloudWithIntensities ToPointCloudWithIntensities(
 
 PointCloudWithIntensities ToPointCloudWithIntensities(
     const sensor_msgs::PointCloud2& message) {
-
   PointCloudWithIntensities point_cloud;
-  //We check for intensity field here to avoid run-time warnings if we pass in a PointCloud2 without intensity.
-  if (PointCloud2HasField(message,"intensity")){
+  // We check for intensity field here to avoid run-time warnings if we pass in
+  // a PointCloud2 without intensity.
+  if (PointCloud2HasField(message, "intensity")) {
     pcl::PointCloud<pcl::PointXYZI> pcl_point_cloud;
     pcl::fromROSMsg(message, pcl_point_cloud);
 
@@ -165,8 +165,8 @@ PointCloudWithIntensities ToPointCloudWithIntensities(
       point_cloud.points.emplace_back(point.x, point.y, point.z);
       point_cloud.intensities.push_back(point.intensity);
     }
-  }
-  else{ //If we don't have an intensity field, just copy XYZ and fill in 1.0.
+  } else {  // If we don't have an intensity field, just copy XYZ and fill in
+            // 1.0.
     pcl::PointCloud<pcl::PointXYZ> pcl_point_cloud;
     pcl::fromROSMsg(message, pcl_point_cloud);
 
@@ -175,7 +175,7 @@ PointCloudWithIntensities ToPointCloudWithIntensities(
       point_cloud.intensities.push_back(1.0);
     }
   }
- 
+
   return point_cloud;
 }
 
@@ -198,11 +198,10 @@ Eigen::Quaterniond ToEigen(const geometry_msgs::Quaternion& quaternion) {
                             quaternion.z);
 }
 
-bool PointCloud2HasField (const sensor_msgs::PointCloud2 &pc2, const std::string field_name)
-{
-  for (size_t cf = 0; cf < pc2.fields.size (); ++cf)
-    if (pc2.fields[cf].name == field_name)
-      return true;
+bool PointCloud2HasField(const sensor_msgs::PointCloud2& pc2,
+                         const std::string field_name) {
+  for (size_t cf = 0; cf < pc2.fields.size(); ++cf)
+    if (pc2.fields[cf].name == field_name) return true;
   return false;
 }
 

--- a/cartographer_ros/cartographer_ros/msg_conversion.cc
+++ b/cartographer_ros/cartographer_ros/msg_conversion.cc
@@ -128,8 +128,8 @@ PointCloudWithIntensities LaserScanToPointCloudWithIntensities(
 
 bool PointCloud2HasField(const sensor_msgs::PointCloud2& pc2,
                          const std::string& field_name) {
-  for (size_t cf = 0; cf < pc2.fields.size(); ++cf) {
-    if (pc2.fields[cf].name == field_name) {
+  for (const auto& field : pc2.fields) {
+    if (field.name == field_name) {
       return true;
     }
   }

--- a/cartographer_ros/cartographer_ros/msg_conversion.cc
+++ b/cartographer_ros/cartographer_ros/msg_conversion.cc
@@ -203,7 +203,7 @@ bool PointCloud2HasField (const sensor_msgs::PointCloud2 &pc2, const std::string
   for (size_t cf = 0; cf < pc2.fields.size (); ++cf)
     if (pc2.fields[cf].name == field_name)
       return true;
-    return false;
+  return false;
 }
 
 PoseCovariance ToPoseCovariance(const boost::array<double, 36>& covariance) {

--- a/cartographer_ros/cartographer_ros/msg_conversion.cc
+++ b/cartographer_ros/cartographer_ros/msg_conversion.cc
@@ -126,6 +126,16 @@ PointCloudWithIntensities LaserScanToPointCloudWithIntensities(
   return point_cloud;
 }
 
+bool PointCloud2HasField(const sensor_msgs::PointCloud2& pc2,
+                         const std::string& field_name) {
+  for (size_t cf = 0; cf < pc2.fields.size(); ++cf) {
+    if (pc2.fields[cf].name == field_name) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 sensor_msgs::PointCloud2 ToPointCloud2Message(
@@ -160,22 +170,21 @@ PointCloudWithIntensities ToPointCloudWithIntensities(
   if (PointCloud2HasField(message, "intensity")) {
     pcl::PointCloud<pcl::PointXYZI> pcl_point_cloud;
     pcl::fromROSMsg(message, pcl_point_cloud);
-
     for (const auto& point : pcl_point_cloud) {
       point_cloud.points.emplace_back(point.x, point.y, point.z);
       point_cloud.intensities.push_back(point.intensity);
     }
-  } else {  // If we don't have an intensity field, just copy XYZ and fill in
-            // 1.0.
+  } else {
     pcl::PointCloud<pcl::PointXYZ> pcl_point_cloud;
     pcl::fromROSMsg(message, pcl_point_cloud);
 
+    // If we don't have an intensity field, just copy XYZ and fill in
+    // 1.0.
     for (const auto& point : pcl_point_cloud) {
       point_cloud.points.emplace_back(point.x, point.y, point.z);
       point_cloud.intensities.push_back(1.0);
     }
   }
-
   return point_cloud;
 }
 
@@ -196,13 +205,6 @@ Eigen::Vector3d ToEigen(const geometry_msgs::Vector3& vector3) {
 Eigen::Quaterniond ToEigen(const geometry_msgs::Quaternion& quaternion) {
   return Eigen::Quaterniond(quaternion.w, quaternion.x, quaternion.y,
                             quaternion.z);
-}
-
-bool PointCloud2HasField(const sensor_msgs::PointCloud2& pc2,
-                         const std::string field_name) {
-  for (size_t cf = 0; cf < pc2.fields.size(); ++cf)
-    if (pc2.fields[cf].name == field_name) return true;
-  return false;
 }
 
 PoseCovariance ToPoseCovariance(const boost::array<double, 36>& covariance) {

--- a/cartographer_ros/cartographer_ros/msg_conversion.h
+++ b/cartographer_ros/cartographer_ros/msg_conversion.h
@@ -62,6 +62,8 @@ Eigen::Vector3d ToEigen(const geometry_msgs::Vector3& vector3);
 
 Eigen::Quaterniond ToEigen(const geometry_msgs::Quaternion& quaternion);
 
+bool PointCloud2HasField (const sensor_msgs::PointCloud2 &pc2, const std::string field_name);
+
 ::cartographer::kalman_filter::PoseCovariance ToPoseCovariance(
     const boost::array<double, 36>& covariance);
 

--- a/cartographer_ros/cartographer_ros/msg_conversion.h
+++ b/cartographer_ros/cartographer_ros/msg_conversion.h
@@ -62,8 +62,6 @@ Eigen::Vector3d ToEigen(const geometry_msgs::Vector3& vector3);
 
 Eigen::Quaterniond ToEigen(const geometry_msgs::Quaternion& quaternion);
 
-bool PointCloud2HasField (const sensor_msgs::PointCloud2 &pc2, const std::string field_name);
-
 ::cartographer::kalman_filter::PoseCovariance ToPoseCovariance(
     const boost::array<double, 36>& covariance);
 


### PR DESCRIPTION
This replaces the reading in assets writer which has hardcoded 1.0 values for intensity.

The downside to this patch is that if a pointcloud2 message without intensity arrives, it will fromROSmsg will throw some warnings.

The fix for that is to add a run time check for the intensity field. I can add that if it is preferred.