### PR TITLE
Track Cartographer changes.

### DIFF
--- a/cartographer_ros/cartographer_ros/assets_writer.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer.cc
@@ -35,12 +35,40 @@ namespace {
 
 namespace carto = ::cartographer;
 
+void WriteTrajectory(const std::vector<::cartographer::mapping::TrajectoryNode>&
+                     trajectory_nodes, const std::string& stem
+                 ) {
+  carto::mapping::proto::Trajectory trajectory;
+  for (const auto& node : trajectory_nodes) {
+    const auto& data = *node.constant_data;
+    auto* node_proto = trajectory.add_node();
+    node_proto->set_timestamp(carto::common::ToUniversal(data.time));
+    *node_proto->mutable_pose() =
+        carto::transform::ToProto(node.pose * data.tracking_to_pose);
+  }
+
+  // Write the trajectory.
+  std::ofstream proto_file(stem + ".pb",
+                           std::ios_base::out | std::ios_base::binary);
+  CHECK(trajectory.SerializeToOstream(&proto_file))
+      << "Could not serialize trajectory.";
+  proto_file.close();
+  CHECK(proto_file) << "Could not write trajectory.";
+}
+
+}  // namespace
+
 // Writes an occupancy grid.
-void Write2DAssets(const std::vector<::cartographer::mapping::TrajectoryNode>&
-                       trajectory_nodes,
-                   const NodeOptions& options, const std::string& stem) {
+void Write2DAssets(
+    const std::vector<::cartographer::mapping::TrajectoryNode>&
+        trajectory_nodes,
+    const string& map_frame,
+    const ::cartographer::mapping_2d::proto::SubmapsOptions& submaps_options,
+    const std::string& stem) {
+  WriteTrajectory(trajectory_nodes, stem);
+
   ::nav_msgs::OccupancyGrid occupancy_grid;
-  BuildOccupancyGrid(trajectory_nodes, options, &occupancy_grid);
+  BuildOccupancyGrid(trajectory_nodes, map_frame, submaps_options, &occupancy_grid);
   WriteOccupancyGridToPgmAndYaml(occupancy_grid, stem);
 }
 
@@ -49,6 +77,8 @@ void Write2DAssets(const std::vector<::cartographer::mapping::TrajectoryNode>&
 void Write3DAssets(const std::vector<::cartographer::mapping::TrajectoryNode>&
                        trajectory_nodes,
                    const double voxel_size, const std::string& stem) {
+  WriteTrajectory(trajectory_nodes, stem);
+
   const auto file_writer_factory = [](const string& filename) {
     return carto::common::make_unique<carto::io::StreamFileWriter>(filename);
   };
@@ -86,39 +116,5 @@ void Write3DAssets(const std::vector<::cartographer::mapping::TrajectoryNode>&
   ply_writing_points_processor.Flush();
 }
 
-}  // namespace
-
-void WriteAssets(const std::vector<::cartographer::mapping::TrajectoryNode>&
-                     trajectory_nodes,
-                 const NodeOptions& options, const std::string& stem) {
-  carto::mapping::proto::Trajectory trajectory;
-  for (const auto& node : trajectory_nodes) {
-    const auto& data = *node.constant_data;
-    auto* node_proto = trajectory.add_node();
-    node_proto->set_timestamp(carto::common::ToUniversal(data.time));
-    *node_proto->mutable_pose() =
-        carto::transform::ToProto(node.pose * data.tracking_to_pose);
-  }
-
-  // Write the trajectory.
-  std::ofstream proto_file(stem + ".pb",
-                           std::ios_base::out | std::ios_base::binary);
-  CHECK(trajectory.SerializeToOstream(&proto_file))
-      << "Could not serialize trajectory.";
-  proto_file.close();
-  CHECK(proto_file) << "Could not write trajectory.";
-
-  if (options.map_builder_options.use_trajectory_builder_2d()) {
-    Write2DAssets(trajectory_nodes, options, stem);
-  }
-
-  if (options.map_builder_options.use_trajectory_builder_3d()) {
-    Write3DAssets(trajectory_nodes,
-                  options.map_builder_options.trajectory_builder_3d_options()
-                      .submaps_options()
-                      .high_resolution(),
-                  stem);
-  }
-}
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/assets_writer.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer.cc
@@ -68,7 +68,7 @@ void Write2DAssets(
   WriteTrajectory(trajectory_nodes, stem);
 
   ::nav_msgs::OccupancyGrid occupancy_grid;
-  BuildOccupancyGrid(trajectory_nodes, map_frame, submaps_options,
+  BuildOccupancyGrid2D(trajectory_nodes, map_frame, submaps_options,
                      &occupancy_grid);
   WriteOccupancyGridToPgmAndYaml(occupancy_grid, stem);
 }

--- a/cartographer_ros/cartographer_ros/assets_writer.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer.cc
@@ -69,7 +69,7 @@ void Write2DAssets(
 
   ::nav_msgs::OccupancyGrid occupancy_grid;
   BuildOccupancyGrid2D(trajectory_nodes, map_frame, submaps_options,
-                     &occupancy_grid);
+                       &occupancy_grid);
   WriteOccupancyGridToPgmAndYaml(occupancy_grid, stem);
 }
 

--- a/cartographer_ros/cartographer_ros/assets_writer.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer.cc
@@ -36,8 +36,8 @@ namespace {
 namespace carto = ::cartographer;
 
 void WriteTrajectory(const std::vector<::cartographer::mapping::TrajectoryNode>&
-                     trajectory_nodes, const std::string& stem
-                 ) {
+                         trajectory_nodes,
+                     const std::string& stem) {
   carto::mapping::proto::Trajectory trajectory;
   for (const auto& node : trajectory_nodes) {
     const auto& data = *node.constant_data;
@@ -68,7 +68,8 @@ void Write2DAssets(
   WriteTrajectory(trajectory_nodes, stem);
 
   ::nav_msgs::OccupancyGrid occupancy_grid;
-  BuildOccupancyGrid(trajectory_nodes, map_frame, submaps_options, &occupancy_grid);
+  BuildOccupancyGrid(trajectory_nodes, map_frame, submaps_options,
+                     &occupancy_grid);
   WriteOccupancyGridToPgmAndYaml(occupancy_grid, stem);
 }
 
@@ -115,6 +116,5 @@ void Write3DAssets(const std::vector<::cartographer::mapping::TrajectoryNode>&
   }
   ply_writing_points_processor.Flush();
 }
-
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/assets_writer.h
+++ b/cartographer_ros/cartographer_ros/assets_writer.h
@@ -25,10 +25,19 @@
 
 namespace cartographer_ros {
 
-// Writes all assets derivable from the 'trajectory_nodes' and 'options'.
-void WriteAssets(const std::vector<::cartographer::mapping::TrajectoryNode>&
-                     trajectory_nodes,
-                 const NodeOptions& options, const std::string& stem);
+// Writes a trajectory proto and an occupancy grid.
+void Write2DAssets(
+    const std::vector<::cartographer::mapping::TrajectoryNode>&
+        trajectory_nodes,
+    const string& map_frame,
+    const ::cartographer::mapping_2d::proto::SubmapsOptions& submaps_options,
+    const std::string& stem);
+
+// Writes X-ray images, trajectory proto, and PLY files from the
+// 'trajectory_nodes'. The filenames will all start with 'stem'.
+void Write3DAssets(const std::vector<::cartographer::mapping::TrajectoryNode>&
+                       trajectory_nodes,
+                   const double voxel_size, const std::string& stem);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -32,8 +32,8 @@ MapBuilderBridge::MapBuilderBridge(const NodeOptions& options,
 int MapBuilderBridge::AddTrajectory(
     const std::unordered_set<string>& expected_sensor_ids,
     const string& tracking_frame) {
-  const int trajectory_id =
-      map_builder_.AddTrajectoryBuilder(expected_sensor_ids, options_.trajectory_builder_options);
+  const int trajectory_id = map_builder_.AddTrajectoryBuilder(
+      expected_sensor_ids, options_.trajectory_builder_options);
   LOG(INFO) << "Added trajectory with ID '" << trajectory_id << "'.";
 
   CHECK_EQ(sensor_bridges_.count(trajectory_id), 0);

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -129,13 +129,15 @@ cartographer_ros_msgs::SubmapList MapBuilderBridge::GetSubmapList() {
 
 std::unique_ptr<nav_msgs::OccupancyGrid>
 MapBuilderBridge::BuildOccupancyGrid() {
+  CHECK(options_.map_builder_options.use_trajectory_builder_2d())
+      << "Publishing OccupancyGrids for 3D data is not yet supported";
   const auto trajectory_nodes =
       map_builder_.sparse_pose_graph()->GetTrajectoryNodes();
   std::unique_ptr<nav_msgs::OccupancyGrid> occupancy_grid;
   if (!trajectory_nodes.empty()) {
     occupancy_grid =
         cartographer::common::make_unique<nav_msgs::OccupancyGrid>();
-    cartographer_ros::BuildOccupancyGrid(
+    BuildOccupancyGrid2D(
         trajectory_nodes, options_.map_frame,
         options_.trajectory_builder_options.trajectory_builder_2d_options()
             .submaps_options(),

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.h
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.h
@@ -22,6 +22,7 @@
 #include <unordered_set>
 
 #include "cartographer/mapping/map_builder.h"
+#include "cartographer/mapping/proto/trajectory_builder_options.pb.h"
 #include "cartographer_ros/node_options.h"
 #include "cartographer_ros/sensor_bridge.h"
 #include "cartographer_ros/tf_bridge.h"

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -113,7 +113,7 @@ void Run() {
   ::ros::Subscriber imu_subscriber;
   if (options.map_builder_options.use_trajectory_builder_3d() ||
       (options.map_builder_options.use_trajectory_builder_2d() &&
-       options.map_builder_options.trajectory_builder_2d_options()
+       options.trajectory_builder_options.trajectory_builder_2d_options()
            .use_imu_data())) {
     imu_subscriber = node.node_handle()->subscribe(
         kImuTopic, kInfiniteSubscriberQueueSize,

--- a/cartographer_ros/cartographer_ros/node_options.cc
+++ b/cartographer_ros/cartographer_ros/node_options.cc
@@ -27,6 +27,9 @@ NodeOptions CreateNodeOptions(
   options.map_builder_options =
       ::cartographer::mapping::CreateMapBuilderOptions(
           lua_parameter_dictionary->GetDictionary("map_builder").get());
+  options.trajectory_builder_options =
+      ::cartographer::mapping::CreateTrajectoryBuilderOptions(
+          lua_parameter_dictionary->GetDictionary("trajectory_builder").get());
   options.map_frame = lua_parameter_dictionary->GetString("map_frame");
   options.tracking_frame =
       lua_parameter_dictionary->GetString("tracking_frame");

--- a/cartographer_ros/cartographer_ros/node_options.h
+++ b/cartographer_ros/cartographer_ros/node_options.h
@@ -29,7 +29,8 @@ namespace cartographer_ros {
 // Top-level options of Cartographer's ROS integration.
 struct NodeOptions {
   ::cartographer::mapping::proto::MapBuilderOptions map_builder_options;
-  ::cartographer::mapping::proto::TrajectoryBuilderOptions trajectory_builder_options;
+  ::cartographer::mapping::proto::TrajectoryBuilderOptions
+      trajectory_builder_options;
   string map_frame;
   string tracking_frame;
   string published_frame;

--- a/cartographer_ros/cartographer_ros/node_options.h
+++ b/cartographer_ros/cartographer_ros/node_options.h
@@ -29,6 +29,7 @@ namespace cartographer_ros {
 // Top-level options of Cartographer's ROS integration.
 struct NodeOptions {
   ::cartographer::mapping::proto::MapBuilderOptions map_builder_options;
+  ::cartographer::mapping::proto::TrajectoryBuilderOptions trajectory_builder_options;
   string map_frame;
   string tracking_frame;
   string published_frame;

--- a/cartographer_ros/cartographer_ros/occupancy_grid.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.cc
@@ -27,8 +27,8 @@ namespace cartographer_ros {
 void BuildOccupancyGrid(
     const std::vector<::cartographer::mapping::TrajectoryNode>&
         trajectory_nodes,
-        const string& map_frame,
-        const ::cartographer::mapping_2d::proto::SubmapsOptions& submaps_options,
+    const string& map_frame,
+    const ::cartographer::mapping_2d::proto::SubmapsOptions& submaps_options,
     ::nav_msgs::OccupancyGrid* const occupancy_grid) {
   namespace carto = ::cartographer;
   const carto::mapping_2d::MapLimits map_limits =

--- a/cartographer_ros/cartographer_ros/occupancy_grid.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.cc
@@ -16,6 +16,9 @@
 
 #include "cartographer_ros/occupancy_grid.h"
 
+#include "cartographer/mapping_2d/map_limits.h"
+#include "cartographer/mapping_2d/probability_grid.h"
+#include "cartographer/mapping_2d/range_data_inserter.h"
 #include "cartographer_ros/time_conversion.h"
 #include "glog/logging.h"
 
@@ -24,14 +27,10 @@ namespace cartographer_ros {
 void BuildOccupancyGrid(
     const std::vector<::cartographer::mapping::TrajectoryNode>&
         trajectory_nodes,
-    const NodeOptions& options,
+        const string& map_frame,
+        const ::cartographer::mapping_2d::proto::SubmapsOptions& submaps_options,
     ::nav_msgs::OccupancyGrid* const occupancy_grid) {
   namespace carto = ::cartographer;
-  CHECK(options.map_builder_options.use_trajectory_builder_2d())
-      << "Publishing OccupancyGrids for 3D data is not yet supported";
-  const auto& submaps_options =
-      options.map_builder_options.trajectory_builder_2d_options()
-          .submaps_options();
   const carto::mapping_2d::MapLimits map_limits =
       carto::mapping_2d::MapLimits::ComputeMapLimits(
           submaps_options.resolution(), trajectory_nodes);
@@ -47,7 +46,7 @@ void BuildOccupancyGrid(
   }
 
   occupancy_grid->header.stamp = ToRos(trajectory_nodes.back().time());
-  occupancy_grid->header.frame_id = options.map_frame;
+  occupancy_grid->header.frame_id = map_frame;
   occupancy_grid->info.map_load_time = occupancy_grid->header.stamp;
 
   Eigen::Array2i offset;

--- a/cartographer_ros/cartographer_ros/occupancy_grid.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.cc
@@ -24,7 +24,7 @@
 
 namespace cartographer_ros {
 
-void BuildOccupancyGrid(
+void BuildOccupancyGrid2D(
     const std::vector<::cartographer::mapping::TrajectoryNode>&
         trajectory_nodes,
     const string& map_frame,

--- a/cartographer_ros/cartographer_ros/occupancy_grid.h
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.h
@@ -25,7 +25,7 @@
 
 namespace cartographer_ros {
 
-void BuildOccupancyGrid(
+void BuildOccupancyGrid2D(
     const std::vector<::cartographer::mapping::TrajectoryNode>&
         trajectory_nodes,
     const string& map_frame,

--- a/cartographer_ros/cartographer_ros/occupancy_grid.h
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.h
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "cartographer/mapping/trajectory_node.h"
-#include "cartographer_ros/node_options.h"
+#include "cartographer/mapping_2d/proto/submaps_options.pb.h"
 #include "nav_msgs/OccupancyGrid.h"
 
 namespace cartographer_ros {
@@ -28,7 +28,9 @@ namespace cartographer_ros {
 void BuildOccupancyGrid(
     const std::vector<::cartographer::mapping::TrajectoryNode>&
         trajectory_nodes,
-    const NodeOptions& options, ::nav_msgs::OccupancyGrid* occupancy_grid);
+    const string& map_frame,
+    const ::cartographer::mapping_2d::proto::SubmapsOptions& submaps_options,
+    ::nav_msgs::OccupancyGrid* const occupancy_grid);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/offline_node_main.cc
+++ b/cartographer_ros/cartographer_ros/offline_node_main.cc
@@ -140,7 +140,7 @@ void Run(const std::vector<string>& bag_filenames) {
   // required.
   if (options.map_builder_options.use_trajectory_builder_3d() ||
       (options.map_builder_options.use_trajectory_builder_2d() &&
-       options.map_builder_options.trajectory_builder_2d_options()
+       options.trajectory_builder_options.trajectory_builder_2d_options()
            .use_imu_data())) {
     check_insert(kImuTopic);
   }

--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -13,9 +13,11 @@
 -- limitations under the License.
 
 include "map_builder.lua"
+include "trajectory_builder.lua"
 
 options = {
   map_builder = MAP_BUILDER,
+  trajectory_builder = TRAJECTORY_BUILDER,
   map_frame = "map",
   tracking_frame = "base_link",
   published_frame = "base_link",

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -13,9 +13,11 @@
 -- limitations under the License.
 
 include "map_builder.lua"
+include "trajectory_builder.lua"
 
 options = {
   map_builder = MAP_BUILDER,
+  trajectory_builder = TRAJECTORY_BUILDER,
   map_frame = "map",
   tracking_frame = "base_link",
   published_frame = "base_link",

--- a/cartographer_ros/configuration_files/pr2.lua
+++ b/cartographer_ros/configuration_files/pr2.lua
@@ -13,9 +13,11 @@
 -- limitations under the License.
 
 include "map_builder.lua"
+include "trajectory_builder.lua"
 
 options = {
   map_builder = MAP_BUILDER,
+  trajectory_builder = TRAJECTORY_BUILDER,
   map_frame = "map",
   tracking_frame = "base_footprint",
   published_frame = "base_footprint",

--- a/cartographer_ros/configuration_files/revo_lds.lua
+++ b/cartographer_ros/configuration_files/revo_lds.lua
@@ -13,9 +13,11 @@
 -- limitations under the License.
 
 include "map_builder.lua"
+include "trajectory_builder.lua"
 
 options = {
   map_builder = MAP_BUILDER,
+  trajectory_builder = TRAJECTORY_BUILDER,
   map_frame = "map",
   tracking_frame = "horizontal_laser_link",
   published_frame = "horizontal_laser_link",

--- a/cartographer_ros/configuration_files/taurob_tracker.lua
+++ b/cartographer_ros/configuration_files/taurob_tracker.lua
@@ -13,9 +13,11 @@
 -- limitations under the License.
 
 include "map_builder.lua"
+include "trajectory_builder.lua"
 
 options = {
   map_builder = MAP_BUILDER,
+  trajectory_builder = TRAJECTORY_BUILDER,
   map_frame = "map",
   tracking_frame = "base_link",
   published_frame = "odom",


### PR DESCRIPTION
Change googlecartographer/cartographer#248 introduced a separation
between MapBuilder and TrajectoryOptions. The ROS repositiories require
changes to track this modification.

Also a slight refactoring in assets_writer.h to only pass explicitly the options required for writing assets and some include what you use fixes.

Tested with demo_backpack_[23]d.launch.