### PR TITLE
Fix rviz trajectory rendering crash

### DIFF
--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -217,16 +217,16 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodesList() {
     marker.scale.x = kTrajectoryLineStripMarkerScale;
     marker.pose.orientation.w = 1.0;
     for (const auto& node : single_trajectory) {
-      ::geometry_msgs::Point node_point = ToGeometryMsgPoint(
+      const ::geometry_msgs::Point node_point = ToGeometryMsgPoint(
           (node.pose * node.constant_data->tracking_to_pose).translation());
       marker.points.push_back(node_point);
       // Work around the 16384 point limit in rviz by splitting the
-      // trajectory into multiple markers
-      if (marker.points.size() == (1 << 14)) {
+      // trajectory into multiple markers.
+      if (marker.points.size() == 16384) {
         trajectory_nodes_list.markers.push_back(marker);
         marker.id = marker_id++;
         marker.points.clear();
-        // Push back the last point, so the two markers appear connected
+        // Push back the last point, so the two markers appear connected.
         marker.points.push_back(node_point);
       }
     }

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -217,8 +217,18 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodesList() {
     marker.scale.x = kTrajectoryLineStripMarkerScale;
     marker.pose.orientation.w = 1.0;
     for (const auto& node : single_trajectory) {
-      marker.points.push_back(ToGeometryMsgPoint(
-          (node.pose * node.constant_data->tracking_to_pose).translation()));
+      ::geometry_msgs::Point node_point = ToGeometryMsgPoint(
+          (node.pose * node.constant_data->tracking_to_pose).translation());
+      marker.points.push_back(node_point);
+      // Work around the 16384 point limit in rviz by splitting the
+      // trajectory into multiple markers
+      if (marker.points.size() == (1 << 14)) {
+        trajectory_nodes_list.markers.push_back(marker);
+        marker.id = marker_id++;
+        marker.points.clear();
+        // Push back the last point, so the two markers appear connected
+        marker.points.push_back(node_point);
+      }
     }
     trajectory_nodes_list.markers.push_back(marker);
   }


### PR DESCRIPTION
Rviz has a limit of 16384 points per marker. To get around this, each
trajectory is split into multiple markers, each up to 16384 points.
Fixes #366.