### PR TITLE
Fix missing ID handling related to starting trajectory

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -427,9 +427,9 @@ bool Node::HandleStartTrajectory(
     return false;
   }
 
-  std::unordered_set<string> expected_sensor_ids;
   const int trajectory_id = AddTrajectory(options, request.topics);
   LaunchSubscribers(options, request.topics, trajectory_id);
+  response.trajectory_id = trajectory_id;
 
   is_active_trajectory_[trajectory_id] = true;
   return true;
@@ -446,6 +446,7 @@ void Node::StartTrajectoryWithDefaultTopics(const TrajectoryOptions& options) {
 
   const int trajectory_id = AddTrajectory(options, topics);
   LaunchSubscribers(options, topics, trajectory_id);
+  is_active_trajectory_[trajectory_id] = true;
 }
 
 bool Node::HandleFinishTrajectory(


### PR DESCRIPTION
* Remove unused code in `Node::HandleStartTrajectory`.
* Store correct trajectory ID to ROS service response in `Node::HandleStartTrajectory`.
* Register a automatically launched first trajectory to active trajectory list 