### PR TITLE
Return ColorRGBA directly from GetColor

### DIFF
--- a/cartographer_ros/cartographer_ros/color.cc
+++ b/cartographer_ros/cartographer_ros/color.cc
@@ -30,14 +30,16 @@ constexpr float kValue = 0.77f;
 constexpr float kGoldenRatioConjugate = (std::sqrt(5.f) - 1.f) / 2.f;
 constexpr float kAlpha = 1.f;
 
-struct ColorRgb {
-  // r, g, b are from [0,1]
-  float r;
-  float g;
-  float b;
-};
+::std_msgs::ColorRGBA CreateRgba(const float r, const float g, const float b) {
+  ::std_msgs::ColorRGBA result;
+  result.r = r;
+  result.g = g;
+  result.b = b;
+  result.a = kAlpha;
+  return result;
+}
 
-ColorRgb HsvToRgb(const float h, const float s, const float v) {
+::std_msgs::ColorRGBA HsvToRgb(const float h, const float s, const float v) {
   const float h_6 = (h == 1.f) ? 0.f : 6 * h;
   const int h_i = std::floor(h_6);
   const float f = h_6 - h_i;
@@ -47,19 +49,19 @@ ColorRgb HsvToRgb(const float h, const float s, const float v) {
   const float t = v * (1.f - (1.f - f) * s);
 
   if (h_i == 0) {
-    return {v, t, p};
+    return CreateRgba(v, t, p);
   } else if (h_i == 1) {
-    return {q, v, p};
+    return CreateRgba(q, v, p);
   } else if (h_i == 2) {
-    return {p, v, t};
+    return CreateRgba(p, v, t);
   } else if (h_i == 3) {
-    return {p, q, v};
+    return CreateRgba(p, q, v);
   } else if (h_i == 4) {
-    return {t, p, v};
+    return CreateRgba(t, p, v);
   } else if (h_i == 5) {
-    return {v, p, q};
+    return CreateRgba(v, p, q);
   } else {
-    return {0.f, 0.f, 0.f};
+    return CreateRgba(0.f, 0.f, 0.f);
   }
 }
 
@@ -70,13 +72,7 @@ ColorRgb HsvToRgb(const float h, const float s, const float v) {
   // Uniform color sampling using the golden ratio from
   // http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
   const float hue = std::fmod(kInitialHue + kGoldenRatioConjugate * id, 1.f);
-  ColorRgb result = HsvToRgb(hue, kSaturation, kValue);
-  ::std_msgs::ColorRGBA result_rgba;
-  result_rgba.r = result.r;
-  result_rgba.g = result.g;
-  result_rgba.b = result.b;
-  result_rgba.a = kAlpha;
-  return result_rgba;
+  return HsvToRgb(hue, kSaturation, kValue);
 }
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/color.cc
+++ b/cartographer_ros/cartographer_ros/color.cc
@@ -28,9 +28,16 @@ constexpr float kInitialHue = 0.69f;
 constexpr float kSaturation = 0.85f;
 constexpr float kValue = 0.77f;
 constexpr float kGoldenRatioConjugate = (std::sqrt(5.f) - 1.f) / 2.f;
+constexpr float kAlpha = 1.f;
 
-::cartographer_ros::ColorRgb HsvToRgb(const float h, const float s,
-                                      const float v) {
+struct ColorRgb {
+  // r, g, b are from [0,1]
+  float r;
+  float g;
+  float b;
+};
+
+ColorRgb HsvToRgb(const float h, const float s, const float v) {
   const float h_6 = (h == 1.f) ? 0.f : 6 * h;
   const int h_i = std::floor(h_6);
   const float f = h_6 - h_i;
@@ -58,12 +65,18 @@ constexpr float kGoldenRatioConjugate = (std::sqrt(5.f) - 1.f) / 2.f;
 
 }  // namespace
 
-ColorRgb GetColor(int id) {
+::std_msgs::ColorRGBA GetColor(int id) {
   CHECK_GE(id, 0);
   // Uniform color sampling using the golden ratio from
   // http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
   const float hue = std::fmod(kInitialHue + kGoldenRatioConjugate * id, 1.f);
-  return HsvToRgb(hue, kSaturation, kValue);
+  ColorRgb result = HsvToRgb(hue, kSaturation, kValue);
+  ::std_msgs::ColorRGBA result_rgba;
+  result_rgba.r = result.r;
+  result_rgba.g = result.g;
+  result_rgba.b = result.b;
+  result_rgba.a = kAlpha;
+  return result_rgba;
 }
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/color.h
+++ b/cartographer_ros/cartographer_ros/color.h
@@ -21,8 +21,8 @@
 
 namespace cartographer_ros {
 
-// A function for on-demand generation of a colour palette, with every two
-// direct successors having large contrast. Initial hue is from [0, 1>.
+// A function for on-demand generation of a color palette, with every two
+// direct successors having large contrast.
 ::std_msgs::ColorRGBA GetColor(int id);
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/color.h
+++ b/cartographer_ros/cartographer_ros/color.h
@@ -17,18 +17,13 @@
 #ifndef CARTOGRAPHER_ROS_COLOR_MANAGER_H_
 #define CARTOGRAPHER_ROS_COLOR_MANAGER_H_
 
-namespace cartographer_ros {
+#include <std_msgs/ColorRGBA.h>
 
-struct ColorRgb {
-  // r, g, b are from [0,1]
-  float r;
-  float g;
-  float b;
-};
+namespace cartographer_ros {
 
 // A function for on-demand generation of a colour palette, with every two
 // direct successors having large contrast. Initial hue is from [0, 1>.
-ColorRgb GetColor(int id);
+::std_msgs::ColorRGBA GetColor(int id);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -140,7 +140,8 @@ cartographer_ros_msgs::SubmapList MapBuilderBridge::GetSubmapList() {
     for (size_t submap_index = 0; submap_index != submap_transforms.size();
          ++submap_index) {
       cartographer_ros_msgs::SubmapEntry submap_entry;
-      submap_entry.submap_version = submaps->Get(submap_index)->num_range_data();
+      submap_entry.submap_version =
+          submaps->Get(submap_index)->num_range_data();
       submap_entry.pose = ToGeometryMsgPose(submap_transforms[submap_index]);
       trajectory_submap_list.submap.push_back(submap_entry);
     }
@@ -217,11 +218,7 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodesList() {
     marker.type = visualization_msgs::Marker::LINE_STRIP;
     marker.header.stamp = ::ros::Time::now();
     marker.header.frame_id = node_options_.map_frame;
-    const ColorRgb trajectory_color = GetColor(trajectory_id);
-    marker.color.r = trajectory_color.r;
-    marker.color.g = trajectory_color.g;
-    marker.color.b = trajectory_color.b;
-    marker.color.a = 1.0;
+    marker.color = GetColor(trajectory_id);
     marker.scale.x = kTrajectoryLineStripMarkerScale;
     marker.pose.orientation.w = 1.0;
     for (const auto& node : single_trajectory_nodes) {


### PR DESCRIPTION
@wohe here's that small change you mentioned in #375, make `GetColor` return `std_msgs::ColorRGBA` directly.

BTW I have two ways of making this change. In the first version (this pull request), I kept the `ColorRgb` struct for use in `HsvToRgb` because the initializer list (`{r, g, b}`) syntax makes our life easier (`ColorRGBA` can't be constructed directly like this). Another option is in https://github.com/googlecartographer/cartographer_ros/compare/master...larics:color-rgba-2, where I wrote a factory function for `ColorRGBA` which is then used in `HsvToRgb`, and this still looks relatively okay. Let me know which one you prefer. (Or if you have something completely different in mind :) )