### PR TITLE
Build cartographer_ros as a static library

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -37,7 +37,7 @@ set(PACKAGE_DEPENDENCIES
 
 find_package(cartographer REQUIRED)
 include("${CARTOGRAPHER_CMAKE_DIR}/functions.cmake")
-option(BUILD_SHARED_LIBS "Build libcartographer_ros as a shared library." OFF)
+set(BUILD_SHARED_LIBS OFF)
 google_initialize_cartographer_project()
 google_enable_testing()
 

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PACKAGE_DEPENDENCIES
 
 find_package(cartographer REQUIRED)
 include("${CARTOGRAPHER_CMAKE_DIR}/functions.cmake")
+option(BUILD_SHARED_LIBS "Build libcartographer_ros as a shared library." OFF)
 google_initialize_cartographer_project()
 google_enable_testing()
 


### PR DESCRIPTION
This was implicitly set on <= Ubuntu 16.04 when find_package()-ing
GMock in google_enable_testing(). On 17.04, this doesn't happen, and
Catkin builds a shared library by default. cartographer_ros currently
can't be built as a shared library due to a linking problem (which is
a separate issue - #392). This makes building on 17.04 consistent with
older versions of Ubuntu.