### PR TITLE
Ignore empty child_frame_id in odometry message

### DIFF
--- a/cartographer_ros/cartographer_ros/sensor_bridge.cc
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.cc
@@ -16,6 +16,7 @@
 
 #include "cartographer_ros/sensor_bridge.h"
 
+#include "cartographer/common/make_unique.h"
 #include "cartographer_ros/msg_conversion.h"
 #include "cartographer_ros/time_conversion.h"
 
@@ -46,8 +47,13 @@ SensorBridge::SensorBridge(
 void SensorBridge::HandleOdometryMessage(
     const string& sensor_id, const nav_msgs::Odometry::ConstPtr& msg) {
   const carto::common::Time time = FromRos(msg->header.stamp);
-  const auto sensor_to_tracking = tf_bridge_.LookupToTracking(
-      time, CheckNoLeadingSlash(msg->child_frame_id));
+  const auto sensor_to_tracking =
+      msg->child_frame_id.empty()
+          ? ::cartographer::common::make_unique<
+                ::cartographer::transform::Rigid3d>(
+                ::cartographer::transform::Rigid3d::Identity())
+          : tf_bridge_.LookupToTracking(
+                time, CheckNoLeadingSlash(msg->child_frame_id));
   if (sensor_to_tracking != nullptr) {
     trajectory_builder_->AddOdometerData(
         sensor_id, time,


### PR DESCRIPTION
In case `child_frame_id` in the odometry message is empty, assume
identity transform for `sensor_to_tracking`.

Otherwise, when `TfBridge::LookupToTracking` is passed an empty string, errors occur.
Use case: [mit stata center data set](http://projects.csail.mit.edu/stata/downloads.php)