### PR TITLE
Keep waiting before finalization in offline node

### DIFF
--- a/cartographer_ros/cartographer_ros/offline_node_main.cc
+++ b/cartographer_ros/cartographer_ros/offline_node_main.cc
@@ -54,6 +54,9 @@ DEFINE_bool(use_bag_transforms, true,
             "Whether to read, use and republish the transforms from the bag.");
 DEFINE_string(pbstream_filename, "",
               "If non-empty, filename of a pbstream to load.");
+DEFINE_bool(keep_running, false,
+            "Keep running the offline node after all messages from the bag "
+            "have been processed.");
 
 namespace cartographer_ros {
 namespace {
@@ -257,6 +260,11 @@ void Run(const std::vector<string>& bag_filenames) {
     }
 
     bag.close();
+
+    if (FLAGS_keep_running) {
+      ::ros::spin();
+    }
+
     node.map_builder_bridge()->FinishTrajectory(trajectory_id);
   }
 

--- a/cartographer_ros/cartographer_ros/offline_node_main.cc
+++ b/cartographer_ros/cartographer_ros/offline_node_main.cc
@@ -265,6 +265,7 @@ void Run(const std::vector<string>& bag_filenames) {
     if (FLAGS_keep_running) {
       ::ros::WallRate rate(kClockPublishFrequency);
       while (::ros::ok()) {
+        clock.clock += ::ros::Duration(1. / kClockPublishFrequency);
         clock_publisher.publish(clock);
         ::ros::spinOnce();
         rate.sleep();


### PR DESCRIPTION
Addresses #407 by @jihoonl, and #368 (partially).

- The custom SIGINT handler has been removed, in favor of using the standard ROS handler and `ros::ok()`.
- I have tried to use an `AsyncSpinner`, as I originally imagined in #368. This way, we could regularly run trajectory finalization and at the same time keep spinning in a separate thread. Unfortunately, I have run into a multithreading bug which causes memory corruption (if anyone is willing to help me debug this, we can set up a Google hangout one day). 
- This means we have to spin in the main thread. In order to be able to watch the final optimization progress in RViz, without spinning asynchronously, we need to spin before calling `FinishTrajectory()`, because this would block the main thread.
- I have singled out the last two commits because they are a bit hacky (especially the last one), so I expect that you will want one of them (or both) reverted. In cbce5c2, I continue publishing the clock from the last message, frozen in time. This way, e.g. if you restart RViz or hit reset, it still receives the correct clock. The last commit advances this clock with the wall rate - this is a hack to keep some things  in ROS happy (e.g. `rosrun tf view_frames`), and I fully expect you'll want me to revert this, but I'm going for it anyway :-)