### PR TITLE
Display submap poses in Submaps plugin

### DIFF
--- a/cartographer_rviz/cartographer_rviz/drawable_submap.h
+++ b/cartographer_rviz/cartographer_rviz/drawable_submap.h
@@ -100,7 +100,7 @@ class DrawableSubmap : public QObject {
   ::rviz::DisplayContext* const display_context_;
   Ogre::SceneNode* const scene_node_;
   Ogre::SceneNode* const submap_node_;
-  Ogre::ManualObject* manual_object_;
+  Ogre::ManualObject* const manual_object_;
   Ogre::TexturePtr texture_;
   Ogre::MaterialPtr material_;
   ::cartographer::transform::Rigid3d pose_ GUARDED_BY(mutex_);

--- a/cartographer_rviz/cartographer_rviz/drawable_submap.h
+++ b/cartographer_rviz/cartographer_rviz/drawable_submap.h
@@ -38,6 +38,7 @@
 #include "ros/ros.h"
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
+#include "rviz/ogre_helpers/axes.h"
 #include "rviz/properties/bool_property.h"
 
 namespace cartographer_rviz {
@@ -48,10 +49,10 @@ class DrawableSubmap : public QObject {
   Q_OBJECT
 
  public:
-  // The 'scene_manager' is the Ogre scene manager to which to add a node.
   DrawableSubmap(const ::cartographer::mapping::SubmapId& submap_id,
-                 Ogre::SceneManager* scene_manager,
-                 ::rviz::Property* submap_category, const bool visible);
+                 ::rviz::DisplayContext* display_context,
+                 ::rviz::Property* submap_category, bool visible,
+                 float pose_axes_length, float pose_axes_radius);
   ~DrawableSubmap() override;
   DrawableSubmap(const DrawableSubmap&) = delete;
   DrawableSubmap& operator=(const DrawableSubmap&) = delete;
@@ -96,12 +97,14 @@ class DrawableSubmap : public QObject {
   const ::cartographer::mapping::SubmapId id_;
 
   ::cartographer::common::Mutex mutex_;
-  Ogre::SceneManager* const scene_manager_;
+  ::rviz::DisplayContext* const display_context_;
   Ogre::SceneNode* const scene_node_;
+  Ogre::SceneNode* const submap_node_;
   Ogre::ManualObject* manual_object_;
   Ogre::TexturePtr texture_;
   Ogre::MaterialPtr material_;
   ::cartographer::transform::Rigid3d pose_ GUARDED_BY(mutex_);
+  ::rviz::Axes pose_axes_;
   std::chrono::milliseconds last_query_timestamp_ GUARDED_BY(mutex_);
   bool query_in_progress_ = false GUARDED_BY(mutex_);
   int metadata_version_ = -1 GUARDED_BY(mutex_);

--- a/cartographer_rviz/cartographer_rviz/submaps_display.cc
+++ b/cartographer_rviz/cartographer_rviz/submaps_display.cc
@@ -133,11 +133,14 @@ void SubmapsDisplay::processMessage(
     auto& trajectory_category = trajectories_[id.trajectory_id].first;
     auto& trajectory = trajectories_[id.trajectory_id].second;
     if (trajectory.count(id.submap_index) == 0) {
-      trajectory.emplace(
-          id.submap_index,
-          ::cartographer::common::make_unique<DrawableSubmap>(
-              id, context_->getSceneManager(), trajectory_category.get(),
-              visibility_all_enabled_->getBool()));
+      // TODO(ojura): Add RViz properties for adjusting submap pose axes
+      constexpr float kSubmapPoseAxesLength = 0.3f;
+      constexpr float kSubmapPoseAxesRadius = 0.06f;
+      trajectory.emplace(id.submap_index,
+                         ::cartographer::common::make_unique<DrawableSubmap>(
+                             id, context_, trajectory_category.get(),
+                             visibility_all_enabled_->getBool(),
+                             kSubmapPoseAxesLength, kSubmapPoseAxesRadius));
     }
     trajectory.at(id.submap_index)
         ->Update(msg->header, submap_entry, context_->getFrameManager());


### PR DESCRIPTION
This is still unpolished, but I thought I might share this if anyone needs it sooner (or wants to provide feedback). Addresses #405 and #404.

Todo and ideas:
 - toggle axes visibility with a checkbox
 - adjustable length/radius
 - add a selection handler
 - show submap ID next to axes, also toggleable with a checkbox
 - option to display axes even if submap is hidden (for using with the regular occupancy grid map plugin)
 - display numeric pose coordinates under an expandable menu for each submap, similar to TF display