### PR TITLE
Add support for subdividing laser scan messages.

### DIFF
--- a/cartographer_ros/cartographer_ros/configuration_files_test.cc
+++ b/cartographer_ros/cartographer_ros/configuration_files_test.cc
@@ -20,6 +20,7 @@
 #include "cartographer/common/configuration_file_resolver.h"
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer_ros/node_options.h"
+#include "cartographer_ros/trajectory_options.h"
 #include "gtest/gtest.h"
 #include "ros/package.h"
 

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -50,6 +50,7 @@ int MapBuilderBridge::AddTrajectory(
   CHECK_EQ(sensor_bridges_.count(trajectory_id), 0);
   sensor_bridges_[trajectory_id] =
       cartographer::common::make_unique<SensorBridge>(
+          trajectory_options.num_subdivisions_per_laser_scan,
           trajectory_options.tracking_frame,
           node_options_.lookup_transform_timeout_sec, tf_buffer_,
           map_builder_.GetTrajectoryBuilder(trajectory_id));

--- a/cartographer_ros/cartographer_ros/node_options.h
+++ b/cartographer_ros/cartographer_ros/node_options.h
@@ -21,7 +21,6 @@
 
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/mapping/map_builder.h"
-#include "cartographer_ros/trajectory_options.h"
 
 namespace cartographer_ros {
 

--- a/cartographer_ros/cartographer_ros/sensor_bridge.h
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.h
@@ -36,8 +36,8 @@ namespace cartographer_ros {
 class SensorBridge {
  public:
   explicit SensorBridge(
-      const string& tracking_frame, double lookup_transform_timeout_sec,
-      tf2_ros::Buffer* tf_buffer,
+      int num_subdivisions_per_laser_scan, const string& tracking_frame,
+      double lookup_transform_timeout_sec, tf2_ros::Buffer* tf_buffer,
       ::cartographer::mapping::TrajectoryBuilder* trajectory_builder);
 
   SensorBridge(const SensorBridge&) = delete;
@@ -58,11 +58,17 @@ class SensorBridge {
   const TfBridge& tf_bridge() const;
 
  private:
+  void HandleLaserScan(const string& sensor_id,
+                       ::cartographer::common::Time start_time,
+                       const string& frame_id,
+                       const ::cartographer::sensor::PointCloud& points,
+                       double seconds_between_points);
   void HandleRangefinder(const string& sensor_id,
-                         const ::cartographer::common::Time time,
+                         ::cartographer::common::Time time,
                          const string& frame_id,
                          const ::cartographer::sensor::PointCloud& ranges);
 
+  const int num_subdivisions_per_laser_scan_;
   const TfBridge tf_bridge_;
   ::cartographer::mapping::TrajectoryBuilder* const trajectory_builder_;
 };

--- a/cartographer_ros/cartographer_ros/trajectory_options.h
+++ b/cartographer_ros/cartographer_ros/trajectory_options.h
@@ -36,6 +36,7 @@ struct TrajectoryOptions {
   bool use_odometry;
   bool use_laser_scan;
   bool use_multi_echo_laser_scan;
+  int num_subdivisions_per_laser_scan;
   int num_point_clouds;
 };
 

--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -26,6 +26,7 @@ options = {
   use_odometry = false,
   use_laser_scan = false,
   use_multi_echo_laser_scan = true,
+  num_subdivisions_per_laser_scan = 10,
   num_point_clouds = 0,
   lookup_transform_timeout_sec = 0.2,
   submap_publish_period_sec = 0.3,
@@ -34,5 +35,6 @@ options = {
 }
 
 MAP_BUILDER.use_trajectory_builder_2d = true
+TRAJECTORY_BUILDER_2D.scans_per_accumulation = 10
 
 return options

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -26,6 +26,7 @@ options = {
   use_odometry = false,
   use_laser_scan = false,
   use_multi_echo_laser_scan = false,
+  num_subdivisions_per_laser_scan = 1,
   num_point_clouds = 2,
   lookup_transform_timeout_sec = 0.2,
   submap_publish_period_sec = 0.3,

--- a/cartographer_ros/configuration_files/pr2.lua
+++ b/cartographer_ros/configuration_files/pr2.lua
@@ -26,6 +26,7 @@ options = {
   use_odometry = false,
   use_laser_scan = true,
   use_multi_echo_laser_scan = false,
+  num_subdivisions_per_laser_scan = 1,
   num_point_clouds = 0,
   lookup_transform_timeout_sec = 0.2,
   submap_publish_period_sec = 0.3,

--- a/cartographer_ros/configuration_files/revo_lds.lua
+++ b/cartographer_ros/configuration_files/revo_lds.lua
@@ -26,6 +26,7 @@ options = {
   use_odometry = false,
   use_laser_scan = true,
   use_multi_echo_laser_scan = false,
+  num_subdivisions_per_laser_scan = 1,
   num_point_clouds = 0,
   lookup_transform_timeout_sec = 0.2,
   submap_publish_period_sec = 0.3,

--- a/cartographer_ros/configuration_files/taurob_tracker.lua
+++ b/cartographer_ros/configuration_files/taurob_tracker.lua
@@ -26,6 +26,7 @@ options = {
   use_odometry = true,
   use_laser_scan = true,
   use_multi_echo_laser_scan = false,
+  num_subdivisions_per_laser_scan = 1,
   num_point_clouds = 0,
   lookup_transform_timeout_sec = 0.2,
   submap_publish_period_sec = 0.3,

--- a/cartographer_ros_msgs/msg/TrajectoryOptions.msg
+++ b/cartographer_ros_msgs/msg/TrajectoryOptions.msg
@@ -19,6 +19,7 @@ bool provide_odom_frame
 bool use_odometry
 bool use_laser_scan
 bool use_multi_echo_laser_scan
+int32 num_subdivisions_per_laser_scan
 int32 num_point_clouds
 
 # This is a binary-encoded


### PR DESCRIPTION
This adds an option to subdivide sensor_msgs/LaserScan and
sensor_msgs/MultiEchoLaserScan messages into multiple point
clouds. For slow spinning laser scanners this allows unwarping
using googlecartographer/cartographer#408.