### PR TITLE
Fix flickering submaps.

### DIFF
--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -255,9 +255,9 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetConstraintList() {
       // Color mapping for submaps of various trajectories - add trajectory id
       // to ensure different starting colors. Also add a fixed offset of 25
       // to avoid having identical colors as trajectories.
-      color_constraint = ToMessage(cartographer::io::GetColor(
-          constraint.submap_id.submap_index +
-          constraint.submap_id.trajectory_id + 25));
+      color_constraint = ToMessage(
+          cartographer::io::GetColor(constraint.submap_id.submap_index +
+                                     constraint.submap_id.trajectory_id + 25));
       color_residual.a = 1.0;
       color_residual.r = 1.0;
     } else {

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -71,9 +71,8 @@ class Node {
   bool HandleFinishTrajectory(
       cartographer_ros_msgs::FinishTrajectory::Request& request,
       cartographer_ros_msgs::FinishTrajectory::Response& response);
-  bool HandleWriteState(
-      cartographer_ros_msgs::WriteState::Request& request,
-      cartographer_ros_msgs::WriteState::Response& response);
+  bool HandleWriteState(cartographer_ros_msgs::WriteState::Request& request,
+                        cartographer_ros_msgs::WriteState::Response& response);
   // Returns the set of topic names we want to subscribe to.
   std::unordered_set<string> ComputeExpectedTopics(
       const TrajectoryOptions& options,

--- a/cartographer_ros/cartographer_ros/offline_node_main.cc
+++ b/cartographer_ros/cartographer_ros/offline_node_main.cc
@@ -273,7 +273,8 @@ void Run(const std::vector<string>& bag_filenames) {
             << (cpu_timespec.tv_sec + 1e-9 * cpu_timespec.tv_nsec) << " s";
 #endif
 
-  node.map_builder_bridge()->SerializeState(bag_filenames.front() + ".pbstream");
+  node.map_builder_bridge()->SerializeState(bag_filenames.front() +
+                                            ".pbstream");
 }
 
 }  // namespace

--- a/cartographer_rviz/cartographer_rviz/drawable_submap.h
+++ b/cartographer_rviz/cartographer_rviz/drawable_submap.h
@@ -91,7 +91,6 @@ class DrawableSubmap : public QObject {
   void ToggleVisibility();
 
  private:
-  void UpdateTransform();
   float UpdateAlpha(float target_alpha);
 
   const ::cartographer::mapping::SubmapId id_;


### PR DESCRIPTION
The 'slice_pose' must be updated together with the texture. Right
now it is updated before the texture so the submap will be shown
in the wrong pose for a short time.

The fix is to move the handling of poses over to Ogre:
The 'scene_node_' now transforms both the shown submap and the axes
into the submap frame. The 'submap_node_' applies the 'slice_pose'
so that the textured rectangle is shown in the correct pose in
the submap frame.