### PR TITLE
Make Node thread safe

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -106,7 +106,10 @@ Node::~Node() {}
 
 ::ros::NodeHandle* Node::node_handle() { return &node_handle_; }
 
-MapBuilderBridge* Node::map_builder_bridge() { return &map_builder_bridge_; }
+::cartographer::common::Mutex::Proxy<MapBuilderBridge>
+Node::map_builder_bridge() {
+  return {&map_builder_bridge_, &mutex_};
+}
 
 bool Node::HandleSubmapQuery(
     ::cartographer_ros_msgs::SubmapQuery::Request& request,

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -455,7 +455,9 @@ void Node::FinishAllTrajectories() {
 
 void Node::FinishTrajectory(const int trajectory_id) {
   carto::common::MutexLocker lock(&mutex_);
+  CHECK(is_active_trajectory_.at(trajectory_id));
   map_builder_bridge_.FinishTrajectory(trajectory_id);
+  is_active_trajectory_[trajectory_id] = false;
 }
 
 void Node::HandleOdometryMessage(const int trajectory_id,

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -106,11 +106,6 @@ Node::~Node() {}
 
 ::ros::NodeHandle* Node::node_handle() { return &node_handle_; }
 
-::cartographer::common::Mutex::Proxy<MapBuilderBridge>
-Node::map_builder_bridge() {
-  return {&map_builder_bridge_, &mutex_};
-}
-
 bool Node::HandleSubmapQuery(
     ::cartographer_ros_msgs::SubmapQuery::Request& request,
     ::cartographer_ros_msgs::SubmapQuery::Response& response) {
@@ -456,6 +451,55 @@ void Node::FinishAllTrajectories() {
       map_builder_bridge_.FinishTrajectory(trajectory_id);
     }
   }
+}
+
+void Node::FinishTrajectory(const int trajectory_id) {
+  carto::common::MutexLocker lock(&mutex_);
+  map_builder_bridge_.FinishTrajectory(trajectory_id);
+}
+
+void Node::HandleOdometryMessage(const int trajectory_id,
+                                 const string& sensor_id,
+                                 const nav_msgs::Odometry::ConstPtr& msg) {
+  carto::common::MutexLocker lock(&mutex_);
+  map_builder_bridge_.sensor_bridge(trajectory_id)
+      ->HandleOdometryMessage(sensor_id, msg);
+}
+
+void Node::HandleImuMessage(const int trajectory_id, const string& sensor_id,
+                            const sensor_msgs::Imu::ConstPtr& msg) {
+  carto::common::MutexLocker lock(&mutex_);
+  map_builder_bridge_.sensor_bridge(trajectory_id)
+      ->HandleImuMessage(sensor_id, msg);
+}
+
+void Node::HandleLaserScanMessage(const int trajectory_id,
+                                  const string& sensor_id,
+                                  const sensor_msgs::LaserScan::ConstPtr& msg) {
+  carto::common::MutexLocker lock(&mutex_);
+  map_builder_bridge_.sensor_bridge(trajectory_id)
+      ->HandleLaserScanMessage(sensor_id, msg);
+}
+
+void Node::HandleMultiEchoLaserScanMessage(
+    int trajectory_id, const string& sensor_id,
+    const sensor_msgs::MultiEchoLaserScan::ConstPtr& msg) {
+  carto::common::MutexLocker lock(&mutex_);
+  map_builder_bridge_.sensor_bridge(trajectory_id)
+      ->HandleMultiEchoLaserScanMessage(sensor_id, msg);
+}
+
+void Node::HandlePointCloud2Message(
+    const int trajectory_id, const string& sensor_id,
+    const sensor_msgs::PointCloud2::ConstPtr& msg) {
+  carto::common::MutexLocker lock(&mutex_);
+  map_builder_bridge_.sensor_bridge(trajectory_id)
+      ->HandlePointCloud2Message(sensor_id, msg);
+}
+
+void Node::SerializeState(const string& filename) {
+  carto::common::MutexLocker lock(&mutex_);
+  map_builder_bridge_.SerializeState(filename);
 }
 
 void Node::LoadMap(const std::string& map_filename) {

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -53,6 +53,8 @@ class Node {
 
   // Finishes all yet active trajectories.
   void FinishAllTrajectories();
+  // Finishes a single given trajectory.
+  void FinishTrajectory(int trajectory_id);
 
   // Starts the first trajectory with the default topics.
   void StartTrajectoryWithDefaultTopics(const TrajectoryOptions& options);
@@ -66,12 +68,26 @@ class Node {
       const std::unordered_set<string>& expected_sensor_ids,
       const TrajectoryOptions& options);
 
+  // The following functions handle adding sensor data to a trajectory.
+  void HandleOdometryMessage(int trajectory_id, const string& sensor_id,
+                             const nav_msgs::Odometry::ConstPtr& msg);
+  void HandleImuMessage(int trajectory_id, const string& sensor_id,
+                        const sensor_msgs::Imu::ConstPtr& msg);
+  void HandleLaserScanMessage(int trajectory_id, const string& sensor_id,
+                              const sensor_msgs::LaserScan::ConstPtr& msg);
+  void HandleMultiEchoLaserScanMessage(
+      int trajectory_id, const string& sensor_id,
+      const sensor_msgs::MultiEchoLaserScan::ConstPtr& msg);
+  void HandlePointCloud2Message(int trajectory_id, const string& sensor_id,
+                                const sensor_msgs::PointCloud2::ConstPtr& msg);
+
+  // Serializes the complete Node state.
+  void SerializeState(const string& filename);
+
   // Loads a persisted state to use as a map.
   void LoadMap(const std::string& map_filename);
 
   ::ros::NodeHandle* node_handle();
-
-  ::cartographer::common::Mutex::Proxy<MapBuilderBridge> map_builder_bridge();
 
  private:
   bool HandleSubmapQuery(

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -70,7 +70,8 @@ class Node {
   void LoadMap(const std::string& map_filename);
 
   ::ros::NodeHandle* node_handle();
-  MapBuilderBridge* map_builder_bridge();
+
+  ::cartographer::common::Mutex::Proxy<MapBuilderBridge> map_builder_bridge();
 
  private:
   bool HandleSubmapQuery(

--- a/cartographer_ros/cartographer_ros/offline_node_main.cc
+++ b/cartographer_ros/cartographer_ros/offline_node_main.cc
@@ -173,35 +173,28 @@ void Run(const std::vector<string>& bag_filenames) {
         const string topic = node.node_handle()->resolveName(
             delayed_msg.getTopic(), false /* resolve */);
         if (delayed_msg.isType<sensor_msgs::LaserScan>()) {
-          node.map_builder_bridge()
-              ->sensor_bridge(trajectory_id)
-              ->HandleLaserScanMessage(
-                  topic, delayed_msg.instantiate<sensor_msgs::LaserScan>());
+          node.HandleLaserScanMessage(
+              trajectory_id, topic,
+              delayed_msg.instantiate<sensor_msgs::LaserScan>());
         }
         if (delayed_msg.isType<sensor_msgs::MultiEchoLaserScan>()) {
-          node.map_builder_bridge()
-              ->sensor_bridge(trajectory_id)
-              ->HandleMultiEchoLaserScanMessage(
-                  topic,
-                  delayed_msg.instantiate<sensor_msgs::MultiEchoLaserScan>());
+          node.HandleMultiEchoLaserScanMessage(
+              trajectory_id, topic,
+              delayed_msg.instantiate<sensor_msgs::MultiEchoLaserScan>());
         }
         if (delayed_msg.isType<sensor_msgs::PointCloud2>()) {
-          node.map_builder_bridge()
-              ->sensor_bridge(trajectory_id)
-              ->HandlePointCloud2Message(
-                  topic, delayed_msg.instantiate<sensor_msgs::PointCloud2>());
+          node.HandlePointCloud2Message(
+              trajectory_id, topic,
+              delayed_msg.instantiate<sensor_msgs::PointCloud2>());
         }
         if (delayed_msg.isType<sensor_msgs::Imu>()) {
-          node.map_builder_bridge()
-              ->sensor_bridge(trajectory_id)
-              ->HandleImuMessage(topic,
-                                 delayed_msg.instantiate<sensor_msgs::Imu>());
+          node.HandleImuMessage(trajectory_id, topic,
+                                delayed_msg.instantiate<sensor_msgs::Imu>());
         }
         if (delayed_msg.isType<nav_msgs::Odometry>()) {
-          node.map_builder_bridge()
-              ->sensor_bridge(trajectory_id)
-              ->HandleOdometryMessage(
-                  topic, delayed_msg.instantiate<nav_msgs::Odometry>());
+          node.HandleOdometryMessage(
+              trajectory_id, topic,
+              delayed_msg.instantiate<nav_msgs::Odometry>());
         }
         rosgraph_msgs::Clock clock;
         clock.clock = delayed_msg.getTime();
@@ -225,7 +218,7 @@ void Run(const std::vector<string>& bag_filenames) {
     }
 
     bag.close();
-    node.map_builder_bridge()->FinishTrajectory(trajectory_id);
+    node.FinishTrajectory(trajectory_id);
   }
 
   const std::chrono::time_point<std::chrono::steady_clock> end_time =
@@ -243,8 +236,7 @@ void Run(const std::vector<string>& bag_filenames) {
             << (cpu_timespec.tv_sec + 1e-9 * cpu_timespec.tv_nsec) << " s";
 #endif
 
-  node.map_builder_bridge()->SerializeState(bag_filenames.front() +
-                                            ".pbstream");
+  node.SerializeState(bag_filenames.front() + ".pbstream");
 }
 
 }  // namespace


### PR DESCRIPTION
Accessing the MapBuilderBridge in Node was not previously guarded by a mutex, hence not thread safe.

We concluded yesterday that the Node class should be refactored to include pass-through methods which would lock the Node mutex before invoking the appropriate methods of the map builder bridge. I have come up with a more elegant way to protect access to the map builder bridge, without modifying the rest of the Cartographer codebase, and without duplicating the map builder bridge interface in the Node class, which I think is pretty cool. It's based on the [execution-around-pointer C++ idiom](https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Execute-Around_Pointer). Please have a look at https://github.com/googlecartographer/cartographer/compare/master...larics:mutex-proxy.

Here are some measures of the offline node to see how much this has impacted performance (average of 10-30 measurements):

RViz open, submaps and trajectory visualization active: 172.5 s before, 175.01 s after
RViz closed: 137.7 s before, 140.6 s after

Do you think this is an acceptable performance loss?