### PR TITLE
Fix crash from memory corruption by switching unique_ptr for shared_ptr.

### DIFF
--- a/cartographer_ros/cartographer_ros/sensor_bridge.cc
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.cc
@@ -59,7 +59,7 @@ void SensorBridge::HandleOdometryMessage(
   }
 }
 
-std::unique_ptr<::cartographer::sensor::ImuData> SensorBridge::ToImuData(
+const std::shared_ptr<::cartographer::sensor::ImuData> SensorBridge::ToImuData(
     const sensor_msgs::Imu::ConstPtr& msg) {
   CHECK_NE(msg->linear_acceleration_covariance[0], -1)
       << "Your IMU data claims to not contain linear acceleration measurements "
@@ -82,7 +82,7 @@ std::unique_ptr<::cartographer::sensor::ImuData> SensorBridge::ToImuData(
       << "The IMU frame must be colocated with the tracking frame. "
          "Transforming linear acceleration into the tracking frame will "
          "otherwise be imprecise.";
-  return ::cartographer::common::make_unique<::cartographer::sensor::ImuData>(
+  return std::make_shared<::cartographer::sensor::ImuData>(
       ::cartographer::sensor::ImuData{
           time,
           sensor_to_tracking->rotation() * ToEigen(msg->linear_acceleration),
@@ -91,7 +91,7 @@ std::unique_ptr<::cartographer::sensor::ImuData> SensorBridge::ToImuData(
 
 void SensorBridge::HandleImuMessage(const string& sensor_id,
                                     const sensor_msgs::Imu::ConstPtr& msg) {
-  std::unique_ptr<::cartographer::sensor::ImuData> imu_data = ToImuData(msg);
+  std::shared_ptr<::cartographer::sensor::ImuData> imu_data = ToImuData(msg);
   if (imu_data != nullptr) {
     trajectory_builder_->AddImuData(sensor_id, imu_data->time,
                                     imu_data->linear_acceleration,

--- a/cartographer_ros/cartographer_ros/sensor_bridge.h
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.h
@@ -48,7 +48,7 @@ class SensorBridge {
 
   void HandleOdometryMessage(const string& sensor_id,
                              const nav_msgs::Odometry::ConstPtr& msg);
-  std::unique_ptr<::cartographer::sensor::ImuData> ToImuData(
+  const std::shared_ptr<::cartographer::sensor::ImuData> ToImuData(
       const sensor_msgs::Imu::ConstPtr& msg);
   void HandleImuMessage(const string& sensor_id,
                         const sensor_msgs::Imu::ConstPtr& msg);


### PR DESCRIPTION
This fixes a new crash caused by the use of `unique_ptr`'s.

Without this, things crash immediately after the callback exits (when using IMU data). 