### PR TITLE
Crash fix in offline node.

### DIFF
--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -57,6 +57,15 @@ class Node {
   // Starts the first trajectory with the default topics.
   void StartTrajectoryWithDefaultTopics(const TrajectoryOptions& options);
 
+  // Compute the default topics for the given 'options'.
+  std::unordered_set<string> ComputeDefaultTopics(
+      const TrajectoryOptions& options);
+
+  // Adds a trajectory for offline processing, i.e. not listening to topics.
+  int AddOfflineTrajectory(
+      const std::unordered_set<string>& expected_sensor_ids,
+      const TrajectoryOptions& options);
+
   // Loads a persisted state to use as a map.
   void LoadMap(const std::string& map_filename);
 


### PR DESCRIPTION
This adds trajectories at the Node object. It makes sure all
necessary extrapolators exist. Before the offline node would crash
when extrapolating.

Also deduplicates the logic to compute the topics for a trajectory.