### PR TITLE
Keep offline node running, republish the clock

### DIFF
--- a/cartographer_ros/cartographer_ros/offline_node_main.cc
+++ b/cartographer_ros/cartographer_ros/offline_node_main.cc
@@ -152,9 +152,6 @@ void Run(const std::vector<string>& bag_filenames) {
     rosbag::View view(bag);
     const ::ros::Time begin_time = view.getBeginTime();
     const double duration_in_seconds = (view.getEndTime() - begin_time).toSec();
-    // While the bag is being processed, the message processing loop publishes
-    // the clock, so the clock republish timer is stopped.
-    clock_republish_timer.stop();
 
     // We make sure that tf_messages are published before any data messages, so
     // that tf lookups always work and that tf_buffer has a small cache size -
@@ -232,7 +229,11 @@ void Run(const std::vector<string>& bag_filenames) {
     // which might take a while.
     clock_republish_timer.start();
     node.FinishTrajectory(trajectory_id);
+    clock_republish_timer.stop();
   }
+
+  // Republish the clock after bag processing has been completed.
+  clock_republish_timer.start();
 
   const std::chrono::time_point<std::chrono::steady_clock> end_time =
       std::chrono::steady_clock::now();


### PR DESCRIPTION
Addresses #407 by @jihoonl, and #368 (partially). Previous attempt was in #414, but we concluded that it is not a good approach.

#443 made `Node` thread-safe, which enables us to launch an asynchronous spinner which will handle all ROS callbacks such as message publishing and servicing submap requests. Even when all bag processing ends, we want to keep publishing the submap list and answering submap queries (this is controlled with a new command-line argument in the offline node).

One small problem is that `Node::FinalizeTrajectory` is still a blocking function and keeps the mutex for quite a while, so you can not really view the final optimization in progress, but that we can handle that later.