### PR TITLE
target official ceres 1.12.0 release rather than 1.12.0rc4

### DIFF
--- a/cartographer_ros.rosinstall
+++ b/cartographer_ros.rosinstall
@@ -1,3 +1,3 @@
 - git: {local-name: cartographer, uri: 'https://github.com/googlecartographer/cartographer.git'}
 - git: {local-name: cartographer_ros, uri: 'https://github.com/googlecartographer/cartographer_ros.git'}
-- git: {local-name: ceres-solver, uri: 'https://ceres-solver.googlesource.com/ceres-solver.git', version: '1.12.0rc4'}
+- git: {local-name: ceres-solver, uri: 'https://ceres-solver.googlesource.com/ceres-solver.git', version: '1.12.0'}


### PR DESCRIPTION
Hi cartographer maintainers,

I was wondering if there was interest in targeting the officially released version of ceres-solver (1.12.0). The difference with the 4rth release candidate is very minor (the only actual code change being [this commit](https://github.com/ceres-solver/ceres-solver/commit/8a2da98ac28ccba8d77d5bd9265e93eb6ac6876c))

I'm interested in helping release an initial version of cartographer in ROS Lunar so that users can install it and depend on it more easily.

I'm currently backporting/packaging ceres-solver 1.12.0 on various ROS Lunar supported platforms (Ubuntu X,Y and Z). If the binaries and the source of the project are both tracking the official released version that will allow minimize potential discrepancies in the future.

Thanks!