### PR TITLE
Release mutex in Node during final optimization

### DIFF
--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -77,8 +77,12 @@ void MapBuilderBridge::FinishTrajectory(const int trajectory_id) {
   // Make sure there is a trajectory with 'trajectory_id'.
   CHECK_EQ(sensor_bridges_.count(trajectory_id), 1);
   map_builder_.FinishTrajectory(trajectory_id);
-  map_builder_.sparse_pose_graph()->RunFinalOptimization();
   sensor_bridges_.erase(trajectory_id);
+}
+
+void MapBuilderBridge::RunFinalOptimization() {
+  LOG(INFO) << "Running final trajectory optimization...";
+  map_builder_.sparse_pose_graph()->RunFinalOptimization();
 }
 
 void MapBuilderBridge::SerializeState(const std::string& filename) {

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.h
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.h
@@ -54,6 +54,7 @@ class MapBuilderBridge {
   int AddTrajectory(const std::unordered_set<string>& expected_sensor_ids,
                     const TrajectoryOptions& trajectory_options);
   void FinishTrajectory(int trajectory_id);
+  void RunFinalOptimization();
   void SerializeState(const string& filename);
 
   bool HandleSubmapQuery(

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -428,20 +428,27 @@ bool Node::HandleWriteState(
 }
 
 void Node::FinishAllTrajectories() {
-  carto::common::MutexLocker lock(&mutex_);
-  for (const auto& entry : is_active_trajectory_) {
-    const int trajectory_id = entry.first;
-    if (entry.second) {
-      map_builder_bridge_.FinishTrajectory(trajectory_id);
+  {
+    carto::common::MutexLocker lock(&mutex_);
+    for (auto &entry : is_active_trajectory_) {
+      const int trajectory_id = entry.first;
+      if (entry.second) {
+        map_builder_bridge_.FinishTrajectory(trajectory_id);
+        entry.second = false;
+      }
     }
   }
+  map_builder_bridge_.RunFinalOptimization();
 }
 
 void Node::FinishTrajectory(const int trajectory_id) {
-  carto::common::MutexLocker lock(&mutex_);
-  CHECK(is_active_trajectory_.at(trajectory_id));
-  map_builder_bridge_.FinishTrajectory(trajectory_id);
-  is_active_trajectory_[trajectory_id] = false;
+  {
+    carto::common::MutexLocker lock(&mutex_);
+    CHECK(is_active_trajectory_.at(trajectory_id));
+    map_builder_bridge_.FinishTrajectory(trajectory_id);
+    is_active_trajectory_[trajectory_id] = false;
+  }
+  map_builder_bridge_.RunFinalOptimization();
 }
 
 void Node::HandleOdometryMessage(const int trajectory_id,

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -430,7 +430,7 @@ bool Node::HandleWriteState(
 void Node::FinishAllTrajectories() {
   {
     carto::common::MutexLocker lock(&mutex_);
-    for (auto &entry : is_active_trajectory_) {
+    for (auto& entry : is_active_trajectory_) {
       const int trajectory_id = entry.first;
       if (entry.second) {
         map_builder_bridge_.FinishTrajectory(trajectory_id);


### PR DESCRIPTION
Enables servicing callbacks during the final optimization. This (along with #443 and #468) enables watching in RViz the progress of the final optimization using the offline node.

One question: should the online node also call `RunFinalOptimization()` in `Node::HandleFinishTrajectory`, or only at the end (which is handled by `FinishAllTrajectories`) ? If so, could this be done asynchronously for similar reasons (to avoid stopping callback servicing)?

> No new data should arrive then as this is an assumption WaitForAllComputations() makes.

This is ensured by removing the sensor bridge in `MapBuilderBridge::FinishTrajectory`. Although, if we wanted to insert a new constraint (e.g. landmark), possibly even during the final optimization, this approach will have to be adapted, right?

Fixes #476.