### PR TITLE
configurable occupancy grid publishing speed

### DIFF
--- a/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
@@ -196,7 +196,7 @@ void Node::HandleSubmapList(
     CHECK_EQ(cairo_surface_status(submap_state.surface.get()),
              CAIRO_STATUS_SUCCESS)
         << cairo_status_to_string(
-            cairo_surface_status(submap_state.surface.get()));
+               cairo_surface_status(submap_state.surface.get()));
   }
   last_timestamp_ = msg->header.stamp;
   last_frame_id_ = msg->header.frame_id;
@@ -284,8 +284,10 @@ void Node::PublishOccupancyGrid(const string& frame_id, const ros::Time& time,
       const uint32 packed = pixel_data[y * size.x() + x];
       const unsigned char color = packed >> 16;
       const unsigned char observed = packed >> 8;
-      const int value = observed == 0 ? -1 : ::cartographer::common::RoundToInt(
-                                                 (1. - color / 255.) * 100.);
+      const int value =
+          observed == 0
+              ? -1
+              : ::cartographer::common::RoundToInt((1. - color / 255.) * 100.);
       CHECK_LE(-1, value);
       CHECK_GE(100, value);
       occupancy_grid.data.push_back(value);

--- a/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
@@ -99,7 +99,7 @@ void CairoDrawEachSubmap(
 class Node {
  public:
   explicit Node(double resolution, double publish_period_sec);
-  ~Node();
+  ~Node() {}
 
   Node(const Node&) = delete;
   Node& operator=(const Node&) = delete;
@@ -143,8 +143,6 @@ Node::Node(const double resolution, const double publish_period_sec)
       occupancy_grid_publisher_timer_(
           node_handle_.createWallTimer(::ros::WallDuration(publish_period_sec),
                                        &Node::DrawAndPublish, this)) {}
-
-Node::~Node() {}
 
 void Node::HandleSubmapList(
     const cartographer_ros_msgs::SubmapList::ConstPtr& msg) {


### PR DESCRIPTION
introducing `publish_period_sec` to control the frequency of occupancy grid publisher. It is not necessary to publish occupancy grid for every submap updates.