### PR TITLE
OccupancyGrid(pgm and meta) exporter from pbstream

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -44,6 +44,7 @@ google_enable_testing()
 find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
 
 include(FindPkgConfig)
+pkg_search_module(YAMLCPP REQUIRED yaml-cpp>=0.5.1)
 
 find_package(LuaGoogle REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common io)
@@ -79,6 +80,7 @@ catkin_package(
     # TODO(damonkohler): This should be here but causes Catkin to abort because
     # protobuf specifies a library '-lpthread' instead of just 'pthread'.
     # CARTOGRAPHER
+    YAMLCPP
     PCL
     EIGEN3
     Boost
@@ -96,6 +98,10 @@ add_library(${PROJECT_NAME} ${ALL_SRCS})
 add_subdirectory("cartographer_ros")
 
 target_link_libraries(${PROJECT_NAME} PUBLIC cartographer)
+
+# YAML
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${YAMLCPP_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${YAMLCPP_LIBRARIES})
 
 # Lua
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${LUA_INCLUDE_DIR})

--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -66,3 +66,14 @@ install(TARGETS cartographer_occupancy_grid_node
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+google_binary(cartographer_occupancy_grid_exporter
+  SRCS
+    occupancy_grid_exporter.cc
+)
+
+install(TARGETS cartographer_occupancy_grid_exporter
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/cartographer_ros/cartographer_ros/occupancy_grid.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.cc
@@ -163,19 +163,5 @@ void WriteOccupancyGridInfoToYaml(const OccupancyGridState& grid_state,
   yaml_file.close();
   CHECK(yaml_file) << "Writing '" << yaml_filename << "' failed.";
 }
-}
 
-/*
-for (size_t y = 0; y < gridnfo.height; ++y) {
-  for (size_t x = 0; x < grid.info.width; ++x) {
-    const size_t i = x + (grid.info.height - y - 1) * grid.info.width;
-    if (grid.data[i] >= 0 && grid.data[i] <= 100) {
-      pgm_file.put((100 - grid.data[i]) * 255 / 100);
-    } else {
-      // We choose a value between the free and occupied threshold.
-      constexpr uint8_t kUnknownValue = 128;
-      pgm_file.put(kUnknownValue);
-    }
-  }
-}
-*/
+}  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/occupancy_grid.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.cc
@@ -122,7 +122,7 @@ void WriteOccupancyGridToPgm(const OccupancyGridState& grid_state,
       CHECK_LE(-1, value);
       CHECK_GE(100, value);
       if (value >= 0 && value < 25) {
-        pgm_file.put(255);
+        pgm_file.put((unsigned char)254);
       } else if (value > 65) {
         pgm_file.put(000);
       } else {

--- a/cartographer_ros/cartographer_ros/occupancy_grid.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.cc
@@ -1,0 +1,132 @@
+
+#include "cartographer_ros/occupancy_grid.h"
+
+Eigen::Affine3d ToEigen(const ::cartographer::transform::Rigid3d& rigid3) {
+  return Eigen::Translation3d(rigid3.translation()) * rigid3.rotation();
+}
+
+namespace cartographer_ros {
+
+void CairoDrawEachSubmap(
+    const double scale,
+    std::map<::cartographer::mapping::SubmapId, SubmapState>* submaps,
+    cairo_t* cr, std::function<void(const SubmapState&)> draw_callback) {
+  cairo_scale(cr, scale, scale);
+
+  for (auto& pair : *submaps) {
+    auto& submap_state = pair.second;
+    if (submap_state.surface == nullptr) {
+      return;
+    }
+    const Eigen::Matrix4d homo =
+        ToEigen(submap_state.pose * submap_state.slice_pose).matrix();
+
+    cairo_save(cr);
+    cairo_matrix_t matrix;
+    cairo_matrix_init(&matrix, homo(1, 0), homo(0, 0), -homo(1, 1), -homo(0, 1),
+                      homo(0, 3), -homo(1, 3));
+    cairo_transform(cr, &matrix);
+
+    const double submap_resolution = submap_state.resolution;
+    cairo_scale(cr, submap_resolution, submap_resolution);
+    draw_callback(submap_state);
+    cairo_restore(cr);
+  }
+}
+
+OccupancyGridState DrawOccupancyGrid(
+    std::map<::cartographer::mapping::SubmapId, SubmapState>* submaps,
+    const double resolution) {
+  Eigen::AlignedBox2f bounding_box;
+  {
+    auto surface = ::cartographer::io::MakeUniqueCairoSurfacePtr(
+        cairo_image_surface_create(kCairoFormat, 1, 1));
+    auto cr =
+        ::cartographer::io::MakeUniqueCairoPtr(cairo_create(surface.get()));
+    const auto update_bounding_box = [&bounding_box, &cr](double x, double y) {
+      cairo_user_to_device(cr.get(), &x, &y);
+      bounding_box.extend(Eigen::Vector2f(x, y));
+    };
+
+    CairoDrawEachSubmap(
+        1. / resolution, submaps, cr.get(),
+        [&update_bounding_box, &bounding_box](const SubmapState& submap_state) {
+          update_bounding_box(0, 0);
+          update_bounding_box(submap_state.width, 0);
+          update_bounding_box(0, submap_state.height);
+          update_bounding_box(submap_state.width, submap_state.height);
+        });
+  }
+
+  const int kPaddingPixel = 5;
+  const Eigen::Array2i size(
+      std::ceil(bounding_box.sizes().x()) + 2 * kPaddingPixel,
+      std::ceil(bounding_box.sizes().y()) + 2 * kPaddingPixel);
+  const Eigen::Array2f origin(-bounding_box.min().x() + kPaddingPixel,
+                              -bounding_box.min().y() + kPaddingPixel);
+
+  auto surface = ::cartographer::io::MakeUniqueCairoSurfacePtr(
+      cairo_image_surface_create(kCairoFormat, size.x(), size.y()));
+  {
+    auto cr =
+        ::cartographer::io::MakeUniqueCairoPtr(cairo_create(surface.get()));
+    cairo_set_source_rgba(cr.get(), 0.5, 0.0, 0.0, 1.);
+    cairo_paint(cr.get());
+    cairo_translate(cr.get(), origin.x(), origin.y());
+    CairoDrawEachSubmap(1. / resolution, submaps, cr.get(),
+                        [&cr](const SubmapState& submap_state) {
+                          cairo_set_source_surface(
+                              cr.get(), submap_state.surface.get(), 0., 0.);
+                          cairo_paint(cr.get());
+                        });
+    cairo_surface_flush(surface.get());
+  }
+  return OccupancyGridState(std::move(surface), origin, size);
+}
+
+void WriteOccupancyGridToPgm(const std::string& filename,
+                             const double resolution,
+                             const OccupancyGridState& grid_state) {
+  LOG(INFO) << "Saving map to '" << filename << "'...";
+  std::ofstream pgm_file(filename, std::ios::out | std::ios::binary);
+  const std::string header = "P5\n# Cartographer map; " +
+                             std::to_string(resolution) +
+                             " m/pixel\n" + std::to_string(grid_state.size.x()) +
+                             " " + std::to_string(grid_state.size.y()) + "\n255\n";
+  pgm_file.write(header.data(), header.size());
+
+  const uint32* pixel_data =
+      reinterpret_cast<uint32*>(cairo_image_surface_get_data(grid_state.surface.get()));
+
+  for (int y = 0; y < grid_state.size.y(); ++y) {
+    for (int x = 0; x < grid_state.size.x(); ++x) {
+      const uint32 packed = pixel_data[y * grid_state.size.x() + x];
+      const unsigned char color = packed >> 16;
+      const unsigned char observed = packed >> 8;
+      const int value = observed == 0 ? 128 : ::cartographer::common::RoundToInt(
+                                                 (1. - color / 255.) * 100.);
+      //CHECK_LE(-1, value);
+      //CHECK_GE(100, value);
+      pgm_file.put(255 - value);
+    }
+  }
+
+  pgm_file.close();
+  CHECK(pgm_file) << "Writing '" << filename << "' failed.";
+}
+}
+
+  /*
+  for (size_t y = 0; y < gridnfo.height; ++y) {
+    for (size_t x = 0; x < grid.info.width; ++x) {
+      const size_t i = x + (grid.info.height - y - 1) * grid.info.width;
+      if (grid.data[i] >= 0 && grid.data[i] <= 100) {
+        pgm_file.put((100 - grid.data[i]) * 255 / 100);
+      } else {
+        // We choose a value between the free and occupied threshold.
+        constexpr uint8_t kUnknownValue = 128;
+        pgm_file.put(kUnknownValue);
+      }
+    }
+  }
+  */

--- a/cartographer_ros/cartographer_ros/occupancy_grid.h
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.h
@@ -61,6 +61,7 @@ void WriteOccupancyGridInfoToYaml(const OccupancyGridState& grid_state,
                                   const double resolution,
                                   const std::string& map_filename,
                                   const std::string& filename);
-}
+
+}  // namespace cartographer_ros
 
 #endif  // CARTOGRAPHER_ROS_OCCUPANCY_GRID_H_

--- a/cartographer_ros/cartographer_ros/occupancy_grid.h
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.h
@@ -1,8 +1,9 @@
 #ifndef CARTOGRAPHER_ROS_OCCUPANCY_GRID_H_
 #define CARTOGRAPHER_ROS_OCCUPANCY_GRID_H_
 
-#include "Eigen/Geometry"
+#include <fstream>
 
+#include "Eigen/Geometry"
 #include "cairo/cairo.h"
 #include "cartographer/io/image.h"
 #include "cartographer/mapping/id.h"

--- a/cartographer_ros/cartographer_ros/occupancy_grid.h
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.h
@@ -1,0 +1,57 @@
+#ifndef CARTOGRAPHER_ROS_OCCUPANCY_GRID_H_
+#define CARTOGRAPHER_ROS_OCCUPANCY_GRID_H_
+
+#include "Eigen/Geometry"
+
+#include "cairo/cairo.h"
+#include "cartographer/io/image.h"
+#include "cartographer/mapping/id.h"
+#include "cartographer/transform/rigid_transform.h"
+
+namespace cartographer_ros {
+
+constexpr cairo_format_t kCairoFormat = CAIRO_FORMAT_ARGB32;
+
+struct OccupancyGridState {
+  OccupancyGridState(::cartographer::io::UniqueCairoSurfacePtr surface,
+                     Eigen::Array2f origin, Eigen::Array2i size)
+      : surface(std::move(surface)), origin(origin), size(size) {}
+  ::cartographer::io::UniqueCairoSurfacePtr surface;
+  Eigen::Array2f origin;
+  Eigen::Array2i size;
+};
+
+struct SubmapState {
+  SubmapState()
+      : surface(::cartographer::io::MakeUniqueCairoSurfacePtr(nullptr)) {}
+
+  // Texture data.
+  int width;
+  int height;
+  int version;
+  double resolution;
+  ::cartographer::transform::Rigid3d slice_pose;
+  ::cartographer::io::UniqueCairoSurfacePtr surface;
+  // Pixel data used by 'surface'. Must outlive 'surface'.
+  std::vector<uint32_t> cairo_data;
+
+  // Metadata.
+  ::cartographer::transform::Rigid3d pose;
+  int metadata_version = -1;
+};
+
+void CairoDrawEachSubmap(
+    const double scale,
+    std::map<::cartographer::mapping::SubmapId, SubmapState>* submaps,
+    cairo_t* cr, std::function<void(const SubmapState&)> draw_callback);
+
+OccupancyGridState DrawOccupancyGrid(
+    std::map<::cartographer::mapping::SubmapId, SubmapState>* submaps,
+    const double resolution);
+
+void WriteOccupancyGridToPgm(const std::string& filename,
+                             const double resolution,
+                             const OccupancyGridState& grid_state);
+}
+
+#endif  // CARTOGRAPHER_ROS_OCCUPANCY_GRID_H_

--- a/cartographer_ros/cartographer_ros/occupancy_grid.h
+++ b/cartographer_ros/cartographer_ros/occupancy_grid.h
@@ -49,9 +49,17 @@ OccupancyGridState DrawOccupancyGrid(
     std::map<::cartographer::mapping::SubmapId, SubmapState>* submaps,
     const double resolution);
 
-void WriteOccupancyGridToPgm(const std::string& filename,
+void ExportOccupancyGrid(const OccupancyGridState& grid_state,
+                         const double resolution, const std::string& stem);
+
+void WriteOccupancyGridToPgm(const OccupancyGridState& grid_state,
                              const double resolution,
-                             const OccupancyGridState& grid_state);
+                             const std::string& filename);
+
+void WriteOccupancyGridInfoToYaml(const OccupancyGridState& grid_state,
+                                  const double resolution,
+                                  const std::string& map_filename,
+                                  const std::string& filename);
 }
 
 #endif  // CARTOGRAPHER_ROS_OCCUPANCY_GRID_H_

--- a/cartographer_ros/cartographer_ros/occupancy_grid_exporter.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_exporter.cc
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cartographer/common/configuration_file_resolver.h"
+#include "cartographer/io/proto_stream.h"
+#include "cartographer/mapping/proto/serialization.pb.h"
+#include "cartographer/mapping_2d/submaps.h"
+#include "cartographer/mapping_2d/xy_index.h"
+#include "cartographer/transform/rigid_transform.h"
+#include "cartographer/transform/transform.h"
+#include "cartographer_ros/occupancy_grid.h"
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+DEFINE_double(resolution, 0.05,
+              "Proto stream file containing the pose graph.");
+DEFINE_string(pose_graph_filename, "",
+              "Proto stream file containing the pose graph.");
+DEFINE_string(map_filename, "map.pgm",
+              "Proto stream file containing the pose graph.");
+
+namespace cartographer_ros {
+
+namespace {
+namespace carto = ::cartographer;
+
+void FillSubmapState(const carto::transform::Rigid3d& submap_pose,
+                     const carto::mapping::proto::Submap& proto,
+                     SubmapState* submap_state) {
+  auto submap_2d = proto.submap_2d();
+  auto probability_grid =
+      carto::mapping_2d::ProbabilityGrid(submap_2d.probability_grid());
+  Eigen::Array2i offset;
+  carto::mapping_2d::CellLimits cell_limits;
+
+  probability_grid.ComputeCroppedLimits(&offset, &cell_limits);
+
+  const double resolution = probability_grid.limits().resolution();
+  const double max_x =
+      probability_grid.limits().max().x() - resolution * offset.y();
+  const double max_y =
+      probability_grid.limits().max().y() - resolution * offset.x();
+
+  submap_state->pose = submap_pose;
+  submap_state->metadata_version = submap_2d.num_range_data();
+  submap_state->width = cell_limits.num_x_cells;
+  submap_state->height = cell_limits.num_y_cells;
+  submap_state->resolution = resolution;
+  submap_state->slice_pose =
+      carto::transform::ToRigid3(submap_2d.local_pose()).inverse() *
+      carto::transform::Rigid3d::Translation(Eigen::Vector3d(max_x, max_y, 0.));
+
+  // Properly dealing with a non-common stride would make this code much more
+  // complicated. Let's check that it is not needed.
+  const int expected_stride = 4 * submap_state->width;
+  CHECK_EQ(expected_stride,
+           cairo_format_stride_for_width(kCairoFormat, submap_state->width));
+  submap_state->cairo_data.clear();
+
+  for (const Eigen::Array2i& xy_index :
+       carto::mapping_2d::XYIndexRangeIterator(cell_limits)) {
+    if (probability_grid.IsKnown(xy_index + offset)) {
+      // We would like to add 'delta' but this is not possible using a value and
+      // alpha. We use premultiplied alpha, so when 'delta' is positive we can
+      // add it by setting 'alpha' to zero. If it is negative, we set 'value' to
+      // zero, and use 'alpha' to subtract. This is only correct when the pixel
+      // is currently white, so walls will look too gray. This should be hard to
+      // detect visually for the user, though.
+      const int delta =
+          128 - carto::mapping::ProbabilityToLogOddsInteger(
+                    probability_grid.GetProbability(xy_index + offset));
+      const uint8 alpha = delta > 0 ? 0 : -delta;
+      const uint8 value = delta > 0 ? delta : 0;
+      const uint8 observed = (value == 0 && alpha == 0) ? 0 : 255;
+      submap_state->cairo_data.push_back((alpha << 24) | (value << 16) |
+                                         (observed << 8) | 0);
+
+    } else {
+      constexpr uint8 kUnknownLogOdds = 0;
+      const uint value = static_cast<uint8>(kUnknownLogOdds);
+      const uint alpha = 0;
+      const uint8 observed = 0;
+      submap_state->cairo_data.push_back((alpha << 24) | (value << 16) |
+                                         (observed << 8) | 0);
+    }
+  }
+
+  submap_state->surface = ::cartographer::io::MakeUniqueCairoSurfacePtr(
+      cairo_image_surface_create_for_data(
+          reinterpret_cast<unsigned char*>(submap_state->cairo_data.data()),
+          kCairoFormat, submap_state->width, submap_state->height,
+          expected_stride));
+  CHECK_EQ(cairo_surface_status(submap_state->surface.get()),
+           CAIRO_STATUS_SUCCESS)
+      << cairo_status_to_string(
+          cairo_surface_status(submap_state->surface.get()));
+  return;
+}
+
+void Run(const string& pose_graph_filename, const string& map_filename, const double resolution) {
+  std::map<carto::mapping::SubmapId, SubmapState> submaps;
+
+  LOG(INFO) << "Loading submaps from serialized data";
+
+  // Load submaps from pose graph file
+  carto::io::ProtoStreamReader reader(pose_graph_filename);
+  carto::mapping::proto::SparsePoseGraph pose_graph;
+  CHECK(reader.ReadProto(&pose_graph));
+  for (;;) {
+    carto::mapping::proto::SerializedData proto;
+    if (!reader.ReadProto(&proto)) {
+      break;
+    }
+    if (proto.has_submap()) {
+      auto submap = proto.submap();
+
+      // Supoort only 2d for now
+      if (!submap.has_submap_2d()) {
+        return;
+      }
+
+      carto::mapping::SubmapId id{submap.submap_id().trajectory_id(),
+                                  submap.submap_id().submap_index()};
+      const carto::transform::Rigid3d submap_pose = carto::transform::ToRigid3(
+          pose_graph.trajectory(submap.submap_id().trajectory_id())
+              .submap(submap.submap_id().submap_index())
+              .pose());
+      SubmapState& submap_state = submaps[id];
+      FillSubmapState(submap_pose, submap, &submap_state);
+    }
+  }
+  CHECK(reader.eof());
+
+  // Generate Occupancy Grid
+  LOG(INFO) << "Generate Occupanct Grid from submaps";
+  auto grid_state = DrawOccupancyGrid(&submaps, resolution);
+
+  LOG(INFO) << "Save into " << map_filename;
+  WriteOccupancyGridToPgm(map_filename, resolution, grid_state);
+}
+}
+}
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  FLAGS_logtostderr = true;
+  google::ParseCommandLineFlags(&argc, &argv, true);
+
+  CHECK(!FLAGS_pose_graph_filename.empty())
+      << "-pose_graph_filename is missing.";
+
+  LOG(INFO) << "Pose Graph File : " << FLAGS_pose_graph_filename;
+  LOG(INFO) << "To save : " << FLAGS_map_filename;
+  LOG(INFO) << "Resolution : " << FLAGS_resolution;
+
+  ::cartographer_ros::Run(FLAGS_pose_graph_filename, FLAGS_map_filename, FLAGS_resolution);
+}

--- a/cartographer_ros/cartographer_ros/occupancy_grid_exporter.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_exporter.cc
@@ -24,12 +24,13 @@
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 
+
+DEFINE_string(pbstream_filename, "",
+              "Proto stream file containing the pose graph.");
 DEFINE_double(resolution, 0.05,
-              "Proto stream file containing the pose graph.");
-DEFINE_string(pose_graph_filename, "",
-              "Proto stream file containing the pose graph.");
-DEFINE_string(map_filename, "map.pgm",
-              "Proto stream file containing the pose graph.");
+              "Map Resolution");
+DEFINE_string(stem, "map",
+              "Prefix to export a map and meta data");
 
 namespace cartographer_ros {
 
@@ -109,7 +110,7 @@ void FillSubmapState(const carto::transform::Rigid3d& submap_pose,
   return;
 }
 
-void Run(const string& pose_graph_filename, const string& map_filename, const double resolution) {
+void Run(const string& pose_graph_filename, const string& stem, const double resolution) {
   std::map<carto::mapping::SubmapId, SubmapState> submaps;
 
   LOG(INFO) << "Loading submaps from serialized data";
@@ -147,8 +148,7 @@ void Run(const string& pose_graph_filename, const string& map_filename, const do
   LOG(INFO) << "Generate Occupanct Grid from submaps";
   auto grid_state = DrawOccupancyGrid(&submaps, resolution);
 
-  LOG(INFO) << "Save into " << map_filename;
-  WriteOccupancyGridToPgm(map_filename, resolution, grid_state);
+  ExportOccupancyGrid(grid_state, resolution, stem);
 }
 }
 }
@@ -158,12 +158,12 @@ int main(int argc, char** argv) {
   FLAGS_logtostderr = true;
   google::ParseCommandLineFlags(&argc, &argv, true);
 
-  CHECK(!FLAGS_pose_graph_filename.empty())
-      << "-pose_graph_filename is missing.";
+  CHECK(!FLAGS_pbstream_filename.empty())
+      << "-pbstream_filename is missing.";
 
-  LOG(INFO) << "Pose Graph File : " << FLAGS_pose_graph_filename;
-  LOG(INFO) << "To save : " << FLAGS_map_filename;
+  LOG(INFO) << "Pose Graph File : " << FLAGS_pbstream_filename;
+  LOG(INFO) << "To save : " << FLAGS_stem;
   LOG(INFO) << "Resolution : " << FLAGS_resolution;
 
-  ::cartographer_ros::Run(FLAGS_pose_graph_filename, FLAGS_map_filename, FLAGS_resolution);
+  ::cartographer_ros::Run(FLAGS_pbstream_filename, FLAGS_stem, FLAGS_resolution);
 }

--- a/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
@@ -28,6 +28,7 @@
 #include "cartographer/transform/rigid_transform.h"
 #include "cartographer_ros/msg_conversion.h"
 #include "cartographer_ros/node_constants.h"
+#include "cartographer_ros/occupancy_grid.h"
 #include "cartographer_ros/ros_log_sink.h"
 #include "cartographer_ros/submap.h"
 #include "cartographer_ros_msgs/SubmapList.h"
@@ -43,57 +44,6 @@ namespace cartographer_ros {
 namespace {
 
 using ::cartographer::mapping::SubmapId;
-
-constexpr cairo_format_t kCairoFormat = CAIRO_FORMAT_ARGB32;
-
-Eigen::Affine3d ToEigen(const ::cartographer::transform::Rigid3d& rigid3) {
-  return Eigen::Translation3d(rigid3.translation()) * rigid3.rotation();
-}
-
-struct SubmapState {
-  SubmapState()
-      : surface(::cartographer::io::MakeUniqueCairoSurfacePtr(nullptr)) {}
-
-  // Texture data.
-  int width;
-  int height;
-  int version;
-  double resolution;
-  ::cartographer::transform::Rigid3d slice_pose;
-  ::cartographer::io::UniqueCairoSurfacePtr surface;
-  // Pixel data used by 'surface'. Must outlive 'surface'.
-  std::vector<uint32_t> cairo_data;
-
-  // Metadata.
-  ::cartographer::transform::Rigid3d pose;
-  int metadata_version = -1;
-};
-
-void CairoDrawEachSubmap(
-    const double scale, std::map<SubmapId, SubmapState>* submaps, cairo_t* cr,
-    std::function<void(const SubmapState&)> draw_callback) {
-  cairo_scale(cr, scale, scale);
-
-  for (auto& pair : *submaps) {
-    auto& submap_state = pair.second;
-    if (submap_state.surface == nullptr) {
-      return;
-    }
-    const Eigen::Matrix4d homo =
-        ToEigen(submap_state.pose * submap_state.slice_pose).matrix();
-
-    cairo_save(cr);
-    cairo_matrix_t matrix;
-    cairo_matrix_init(&matrix, homo(1, 0), homo(0, 0), -homo(1, 1), -homo(0, 1),
-                      homo(0, 3), -homo(1, 3));
-    cairo_transform(cr, &matrix);
-
-    const double submap_resolution = submap_state.resolution;
-    cairo_scale(cr, submap_resolution, submap_resolution);
-    draw_callback(submap_state);
-    cairo_restore(cr);
-  }
-}
 
 class Node {
  public:

--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -59,6 +59,7 @@
   <depend>tf2_ros</depend>
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
+  <depend>yaml-cpp</depend>
 
   <test_depend>rosunit</test_depend>
 


### PR DESCRIPTION
This file loads submaps from pbstream file, generates occupancy grid, and exports map server compatible pgm image and yaml file.

Note that `WriteOccupancyGridToPgm` isn't very optimized. So, any optimization suggestion is welcome. And `WriteOccupancyGridInfoToYaml` is copy from old code.

resolves #475 