### PR TITLE
Throttle rviz submap fading warning.

### DIFF
--- a/cartographer_rviz/cartographer_rviz/submaps_display.cc
+++ b/cartographer_rviz/cartographer_rviz/submaps_display.cc
@@ -202,7 +202,7 @@ void SubmapsDisplay::update(const float wall_dt, const float ros_dt) {
       }
     }
   } catch (const tf2::TransformException& ex) {
-    ROS_WARN("Could not compute submap fading: %s", ex.what());
+    ROS_WARN_THROTTLE(1., "Could not compute submap fading: %s", ex.what());
   }
   // Update the map frame to fixed frame transform.
   Ogre::Vector3 position;


### PR DESCRIPTION
RVIZ starts to spam warning when any trajectory is not started yet.