### PR TITLE
Rename to OgreSlice.

### DIFF
--- a/cartographer_rviz/cartographer_rviz/drawable_submap.cc
+++ b/cartographer_rviz/cartographer_rviz/drawable_submap.cc
@@ -58,7 +58,7 @@ DrawableSubmap::DrawableSubmap(const ::cartographer::mapping::SubmapId& id,
       display_context_(display_context),
       submap_node_(map_node->createChildSceneNode()),
       submap_id_text_node_(submap_node_->createChildSceneNode()),
-      ogre_submap_(id, display_context->getSceneManager(), submap_node_),
+      ogre_slice_(id, display_context->getSceneManager(), submap_node_),
       pose_axes_(display_context->getSceneManager(), submap_node_,
                  pose_axes_length, pose_axes_radius),
       submap_id_text_(QString("(%1,%2)")
@@ -162,14 +162,14 @@ void DrawableSubmap::SetAlpha(const double current_tracking_z) {
       target_alpha == 0.f || target_alpha == 1.f) {
     current_alpha_ = target_alpha;
   }
-  ogre_submap_.SetAlpha(current_alpha_);
+  ogre_slice_.SetAlpha(current_alpha_);
   display_context_->queueRender();
 }
 
 void DrawableSubmap::UpdateSceneNode() {
   ::cartographer::common::MutexLocker locker(&mutex_);
   // TODO(gaschler): Add UI feature to show all textures.
-  ogre_submap_.Update(submap_textures_->textures[0]);
+  ogre_slice_.Update(submap_textures_->textures[0]);
   display_context_->queueRender();
 }
 

--- a/cartographer_rviz/cartographer_rviz/drawable_submap.h
+++ b/cartographer_rviz/cartographer_rviz/drawable_submap.h
@@ -30,7 +30,7 @@
 #include "cartographer_ros/submap.h"
 #include "cartographer_ros_msgs/SubmapEntry.h"
 #include "cartographer_ros_msgs/SubmapQuery.h"
-#include "cartographer_rviz/ogre_submap.h"
+#include "cartographer_rviz/ogre_slice.h"
 #include "ros/ros.h"
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
@@ -93,7 +93,7 @@ class DrawableSubmap : public QObject {
   ::rviz::DisplayContext* const display_context_;
   Ogre::SceneNode* const submap_node_;
   Ogre::SceneNode* const submap_id_text_node_;
-  OgreSubmap ogre_submap_;
+  OgreSlice ogre_slice_;
   ::cartographer::transform::Rigid3d pose_ GUARDED_BY(mutex_);
   ::rviz::Axes pose_axes_;
   ::rviz::MovableText submap_id_text_;

--- a/cartographer_rviz/cartographer_rviz/ogre_slice.cc
+++ b/cartographer_rviz/cartographer_rviz/ogre_slice.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "cartographer_rviz/ogre_submap.h"
+#include "cartographer_rviz/ogre_slice.h"
 
 #include <string>
 #include <vector>
@@ -48,9 +48,9 @@ Ogre::Quaternion ToOgre(const Eigen::Quaterniond& q) {
   return Ogre::Quaternion(q.w(), q.x(), q.y(), q.z());
 }
 
-OgreSubmap::OgreSubmap(const ::cartographer::mapping::SubmapId& id,
-                       Ogre::SceneManager* const scene_manager,
-                       Ogre::SceneNode* const submap_node)
+OgreSlice::OgreSlice(const ::cartographer::mapping::SubmapId& id,
+                     Ogre::SceneManager* const scene_manager,
+                     Ogre::SceneNode* const submap_node)
     : id_(id),
       scene_manager_(scene_manager),
       submap_node_(submap_node),
@@ -69,7 +69,7 @@ OgreSubmap::OgreSubmap(const ::cartographer::mapping::SubmapId& id,
   slice_node_->attachObject(manual_object_);
 }
 
-OgreSubmap::~OgreSubmap() {
+OgreSlice::~OgreSlice() {
   Ogre::MaterialManager::getSingleton().remove(material_->getHandle());
   if (!texture_.isNull()) {
     Ogre::TextureManager::getSingleton().remove(texture_->getHandle());
@@ -79,7 +79,7 @@ OgreSubmap::~OgreSubmap() {
   scene_manager_->destroyManualObject(manual_object_);
 }
 
-void OgreSubmap::Update(
+void OgreSlice::Update(
     const ::cartographer_ros::SubmapTexture& submap_texture) {
   slice_node_->setPosition(ToOgre(submap_texture.slice_pose.translation()));
   slice_node_->setOrientation(ToOgre(submap_texture.slice_pose.rotation()));
@@ -136,7 +136,7 @@ void OgreSubmap::Update(
   texture_unit->setTextureFiltering(Ogre::TFO_NONE);
 }
 
-void OgreSubmap::SetAlpha(const float alpha) {
+void OgreSlice::SetAlpha(const float alpha) {
   const Ogre::GpuProgramParametersSharedPtr parameters =
       material_->getTechnique(0)->getPass(0)->getFragmentProgramParameters();
   parameters->setNamedConstant("u_alpha", alpha);

--- a/cartographer_rviz/cartographer_rviz/ogre_slice.h
+++ b/cartographer_rviz/cartographer_rviz/ogre_slice.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef CARTOGRAPHER_RVIZ_SRC_OGRE_SUBMAP_H_
-#define CARTOGRAPHER_RVIZ_SRC_OGRE_SUBMAP_H_
+#ifndef CARTOGRAPHER_RVIZ_SRC_OGRE_SLICE_H_
+#define CARTOGRAPHER_RVIZ_SRC_OGRE_SLICE_H_
 
 #include "Eigen/Core"
 #include "Eigen/Geometry"
@@ -34,19 +34,19 @@ namespace cartographer_rviz {
 Ogre::Vector3 ToOgre(const Eigen::Vector3d& v);
 Ogre::Quaternion ToOgre(const Eigen::Quaterniond& q);
 
-// A class containing the Ogre code to visualize submap data. Member functions
-// are expected to be called from the Ogre thread.
-class OgreSubmap {
+// A class containing the Ogre code to visualize a slice texture of a submap.
+// Member functions are expected to be called from the Ogre thread.
+class OgreSlice {
  public:
   // Attaches a node visualizing the submap 'id' to the 'submap_node' which is
   // expected to represent the submap frame.
-  OgreSubmap(const ::cartographer::mapping::SubmapId& id,
-             Ogre::SceneManager* const scene_manager,
-             Ogre::SceneNode* const submap_node);
-  ~OgreSubmap();
+  OgreSlice(const ::cartographer::mapping::SubmapId& id,
+            Ogre::SceneManager* const scene_manager,
+            Ogre::SceneNode* const submap_node);
+  ~OgreSlice();
 
-  OgreSubmap(const OgreSubmap&) = delete;
-  OgreSubmap& operator=(const OgreSubmap&) = delete;
+  OgreSlice(const OgreSlice&) = delete;
+  OgreSlice& operator=(const OgreSlice&) = delete;
 
   // Updates the texture and pose of the submap using new data from
   // 'submap_texture'.
@@ -67,4 +67,4 @@ class OgreSubmap {
 
 }  // namespace cartographer_rviz
 
-#endif  // CARTOGRAPHER_RVIZ_SRC_OGRE_SUBMAP_H_
+#endif  // CARTOGRAPHER_RVIZ_SRC_OGRE_SLICE_H_


### PR DESCRIPTION
Renames OgreSubmap to OgreSlice in preparation for that a
DrawableSubmap should hold multiple OgreSlices, so multiple
types of slices for one submap can be visualized.