### PR TITLE
Unify finish trajectory logic

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -381,7 +381,8 @@ bool Node::FinishTrajectoryUnderLock(const int trajectory_id) {
     return false;
   }
   if (!is_active_trajectory_[trajectory_id]) {
-    LOG(INFO) << "Trajectory_id " << trajectory_id << " has already been finished.";
+    LOG(INFO) << "Trajectory_id " << trajectory_id
+              << " has already been finished.";
     return false;
   }
 

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -392,6 +392,7 @@ bool Node::FinishTrajectoryUnderLock(const int trajectory_id) {
     subscribed_topics_.erase(entry.topic);
     LOG(INFO) << "Shutdown the subscriber of [" << entry.topic << "]";
   }
+  CHECK_EQ(subscribers_.erase(trajectory_id), 1);
   CHECK(is_active_trajectory_.at(trajectory_id));
   map_builder_bridge_.FinishTrajectory(trajectory_id);
   is_active_trajectory_[trajectory_id] = false;

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -381,8 +381,7 @@ bool Node::FinishTrajectoryUnderLock(const int trajectory_id) {
     return false;
   }
   if (!is_active_trajectory_[trajectory_id]) {
-    LOG(INFO) << "Trajectory_id " << trajectory_id
-              << " has already been finished.";
+    LOG(INFO) << "Trajectory_id " << trajectory_id << " has already been finished.";
     return false;
   }
 

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -421,7 +421,28 @@ bool Node::HandleFinishTrajectory(
     ::cartographer_ros_msgs::FinishTrajectory::Request& request,
     ::cartographer_ros_msgs::FinishTrajectory::Response& response) {
   carto::common::MutexLocker lock(&mutex_);
-  const int trajectory_id = request.trajectory_id;
+  return FinishTrajectory(request.trajectory_id);
+}
+
+bool Node::HandleWriteState(
+    ::cartographer_ros_msgs::WriteState::Request& request,
+    ::cartographer_ros_msgs::WriteState::Response& response) {
+  carto::common::MutexLocker lock(&mutex_);
+  map_builder_bridge_.SerializeState(request.filename);
+  return true;
+}
+
+void Node::FinishAllTrajectories() {
+  carto::common::MutexLocker lock(&mutex_);
+  for (auto& entry : is_active_trajectory_) {
+    const int trajectory_id = entry.first;
+    if (entry.second) {
+      CHECK(FinishTrajectory(trajectory_id));
+    }
+  }
+}
+
+bool Node::FinishTrajectory(const int trajectory_id) {
   if (is_active_trajectory_.count(trajectory_id) == 0) {
     LOG(INFO) << "Trajectory_id " << trajectory_id << " is not created yet.";
     return false;
@@ -438,36 +459,10 @@ bool Node::HandleFinishTrajectory(
     subscribed_topics_.erase(entry.topic);
     LOG(INFO) << "Shutdown the subscriber of [" << entry.topic << "]";
   }
-  CHECK_EQ(subscribers_.erase(trajectory_id), 1);
-  map_builder_bridge_.FinishTrajectory(trajectory_id);
-  is_active_trajectory_[trajectory_id] = false;
-  return true;
-}
-
-bool Node::HandleWriteState(
-    ::cartographer_ros_msgs::WriteState::Request& request,
-    ::cartographer_ros_msgs::WriteState::Response& response) {
-  carto::common::MutexLocker lock(&mutex_);
-  map_builder_bridge_.SerializeState(request.filename);
-  return true;
-}
-
-void Node::FinishAllTrajectories() {
-  carto::common::MutexLocker lock(&mutex_);
-  for (auto& entry : is_active_trajectory_) {
-    const int trajectory_id = entry.first;
-    if (entry.second) {
-      map_builder_bridge_.FinishTrajectory(trajectory_id);
-      entry.second = false;
-    }
-  }
-}
-
-void Node::FinishTrajectory(const int trajectory_id) {
-  carto::common::MutexLocker lock(&mutex_);
   CHECK(is_active_trajectory_.at(trajectory_id));
   map_builder_bridge_.FinishTrajectory(trajectory_id);
   is_active_trajectory_[trajectory_id] = false;
+  return true;
 }
 
 void Node::RunFinalOptimization() {

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -375,6 +375,29 @@ bool Node::ValidateTopicNames(
   return true;
 }
 
+bool Node::FinishTrajectoryUnderLock(const int trajectory_id) {
+  if (is_active_trajectory_.count(trajectory_id) == 0) {
+    LOG(INFO) << "Trajectory_id " << trajectory_id << " is not created yet.";
+    return false;
+  }
+  if (!is_active_trajectory_[trajectory_id]) {
+    LOG(INFO) << "Trajectory_id " << trajectory_id
+              << " has already been finished.";
+    return false;
+  }
+
+  // Shutdown the subscribers of this trajectory.
+  for (auto& entry : subscribers_[trajectory_id]) {
+    entry.subscriber.shutdown();
+    subscribed_topics_.erase(entry.topic);
+    LOG(INFO) << "Shutdown the subscriber of [" << entry.topic << "]";
+  }
+  CHECK(is_active_trajectory_.at(trajectory_id));
+  map_builder_bridge_.FinishTrajectory(trajectory_id);
+  is_active_trajectory_[trajectory_id] = false;
+  return true;
+}
+
 bool Node::HandleStartTrajectory(
     ::cartographer_ros_msgs::StartTrajectory::Request& request,
     ::cartographer_ros_msgs::StartTrajectory::Response& response) {
@@ -421,7 +444,7 @@ bool Node::HandleFinishTrajectory(
     ::cartographer_ros_msgs::FinishTrajectory::Request& request,
     ::cartographer_ros_msgs::FinishTrajectory::Response& response) {
   carto::common::MutexLocker lock(&mutex_);
-  return FinishTrajectory(request.trajectory_id);
+  return FinishTrajectoryUnderLock(request.trajectory_id);
 }
 
 bool Node::HandleWriteState(
@@ -437,32 +460,14 @@ void Node::FinishAllTrajectories() {
   for (auto& entry : is_active_trajectory_) {
     const int trajectory_id = entry.first;
     if (entry.second) {
-      CHECK(FinishTrajectory(trajectory_id));
+      CHECK(FinishTrajectoryUnderLock(trajectory_id));
     }
   }
 }
 
 bool Node::FinishTrajectory(const int trajectory_id) {
-  if (is_active_trajectory_.count(trajectory_id) == 0) {
-    LOG(INFO) << "Trajectory_id " << trajectory_id << " is not created yet.";
-    return false;
-  }
-  if (!is_active_trajectory_[trajectory_id]) {
-    LOG(INFO) << "Trajectory_id " << trajectory_id
-              << " has already been finished.";
-    return false;
-  }
-
-  // Shutdown the subscribers of this trajectory.
-  for (auto& entry : subscribers_[trajectory_id]) {
-    entry.subscriber.shutdown();
-    subscribed_topics_.erase(entry.topic);
-    LOG(INFO) << "Shutdown the subscriber of [" << entry.topic << "]";
-  }
-  CHECK(is_active_trajectory_.at(trajectory_id));
-  map_builder_bridge_.FinishTrajectory(trajectory_id);
-  is_active_trajectory_[trajectory_id] = false;
-  return true;
+  carto::common::MutexLocker lock(&mutex_);
+  return FinishTrajectoryUnderLock(trajectory_id);
 }
 
 void Node::RunFinalOptimization() {

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -54,7 +54,8 @@ class Node {
 
   // Finishes all yet active trajectories.
   void FinishAllTrajectories();
-  // Finishes a single given trajectory.
+  // Finishes a single given trajectory. Returns false if the trajectory did not
+  // exist or was already finished.
   bool FinishTrajectory(int trajectory_id);
 
   // Runs final optimization. All trajectories have to be finished when calling.
@@ -134,6 +135,7 @@ class Node {
   bool ValidateTrajectoryOptions(const TrajectoryOptions& options);
   bool ValidateTopicNames(const ::cartographer_ros_msgs::SensorTopics& topics,
                           const TrajectoryOptions& options);
+  bool FinishTrajectoryUnderLock(int trajectory_id) REQUIRES(mutex_);
 
   const NodeOptions node_options_;
 

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -55,7 +55,7 @@ class Node {
   // Finishes all yet active trajectories.
   void FinishAllTrajectories();
   // Finishes a single given trajectory.
-  void FinishTrajectory(int trajectory_id);
+  bool FinishTrajectory(int trajectory_id);
 
   // Runs final optimization. All trajectories have to be finished when calling.
   void RunFinalOptimization();


### PR DESCRIPTION
Port active trajectory checks and subscriber shutdown logic into FinishTrajectory(), so that a trajectory can be cleanly finished by function call.