### PR TITLE
Don't `set -o verbose` in ros_entrypoint.sh

### DIFF
--- a/scripts/ros_entrypoint.sh
+++ b/scripts/ros_entrypoint.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 set -o errexit
-set -o verbose
 
 source "/opt/ros/${ROS_DISTRO}/setup.bash"
 source "/opt/cartographer_ros/setup.bash"


### PR DESCRIPTION
All it does is source some large scripts, which results in lots of
logspam when the container starts up. It then runs exec, after which the
`verbose` setting has no effect.