### PR TITLE
Increase 3D global localization score threshold.

### DIFF
--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -46,5 +46,6 @@ SPARSE_POSE_GRAPH.optimize_every_n_scans = 320
 SPARSE_POSE_GRAPH.constraint_builder.sampling_ratio = 0.03
 SPARSE_POSE_GRAPH.optimization_problem.ceres_solver_options.max_num_iterations = 10
 SPARSE_POSE_GRAPH.constraint_builder.min_score = 0.62
+SPARSE_POSE_GRAPH.constraint_builder.global_localization_min_score = 0.66
 
 return options

--- a/cartographer_ros/configuration_files/backpack_3d_localization.lua
+++ b/cartographer_ros/configuration_files/backpack_3d_localization.lua
@@ -17,7 +17,4 @@ include "backpack_3d.lua"
 TRAJECTORY_BUILDER.pure_localization = true
 SPARSE_POSE_GRAPH.optimize_every_n_scans = 100
 
--- 3D localization is not working that well, so we choose a low min score.
-SPARSE_POSE_GRAPH.constraint_builder.global_localization_min_score = 0.45
-
 return options


### PR DESCRIPTION
With googlecartographer/cartographer#640 submitted,
global localization in 3D seems to behave as expected,
so there is no longer a need for a low minimum score.

We increase the minimum score to be slightly above the
minimum score used in the same trajectory. This is to
reduce the amount of outliers which are worse in this
case. This change also moves it into the backpack_3d.lua
file since it should also apply to multi-trajectory SLAM.