### PR TITLE
Remove io component of PCL.

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -46,7 +46,7 @@ find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
 include(FindPkgConfig)
 
 find_package(LuaGoogle REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common io)
+find_package(PCL REQUIRED COMPONENTS common)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system iostreams)
 


### PR DESCRIPTION
The `io` component of PCL brings in VTK, which in turn creates a lot of CMake pollution (such as bringing in Qt, which is completely unnecessary for `cartographer_ros`).