### PR TITLE
Launch grpc bridge and server

### DIFF
--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -91,7 +91,7 @@ install(TARGETS cartographer_pbstream_to_ros_map
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-# TODO: Add support for shared libary case.
+# TODO(cschuet): Add support for shared library case.
 if (${BUILD_GRPC})
   google_binary(cartographer_grpc_node
     SRCS
@@ -102,5 +102,10 @@ if (${BUILD_GRPC})
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  )
+
+  install(PROGRAMS
+    scripts/cartographer_grpc_server.sh
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
 endif()

--- a/cartographer_ros/configuration_files/backpack_2d_server.lua
+++ b/cartographer_ros/configuration_files/backpack_2d_server.lua
@@ -1,0 +1,19 @@
+-- Copyright 2018 The Cartographer Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+include "map_builder_server.lua"
+
+MAP_BUILDER_SERVER.map_builder.use_trajectory_builder_2d = true
+
+return MAP_BUILDER_SERVER

--- a/cartographer_ros/launch/grpc_demo_backpack_2d.launch
+++ b/cartographer_ros/launch/grpc_demo_backpack_2d.launch
@@ -1,0 +1,40 @@
+<!--
+  Copyright 2018 The Cartographer Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<launch>
+  <param name="robot_description"
+    textfile="$(find cartographer_ros)/urdf/backpack_2d.urdf" />
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher"
+    type="robot_state_publisher" />
+
+  <node name="cartographer_grpc_server" pkg="cartographer_ros"
+      type="cartographer_grpc_server.sh" args="
+          -configuration_directory $(find cartographer_ros)/configuration_files
+          -configuration_basename backpack_2d_server.lua">
+  </node>
+
+  <node name="cartographer_grpc_node" pkg="cartographer_ros"
+      type="cartographer_grpc_node" args="
+          -configuration_directory $(find cartographer_ros)/configuration_files
+          -configuration_basename backpack_2d.lua"
+      output="screen">
+    <remap from="echoes" to="horizontal_laser_2d" />
+  </node>
+
+  <node name="playbag" pkg="rosbag" type="play"
+        args="--clock $(arg bag_filename)" />
+</launch>

--- a/cartographer_ros/scripts/cartographer_grpc_server.sh
+++ b/cartographer_ros/scripts/cartographer_grpc_server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2018 The Cartographer Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+cartographer_grpc_server $@


### PR DESCRIPTION
Adds a launch file to test the entire grpc bridge.

Here is an example to run:
```
catkin_make_isolated --use-ninja -DBUILD_GRPC=True
source devel_isolated/setup.bash
roslaunch cartographer_ros grpc_demo_backpack_2d.launch bag_filename:=${HOME}/Downloads/cartographer_paper_deutsches_museum.bag
```

The bash script is a work-around to run an executable outside of the catkin packages.