### PR TITLE
Change link ordering to fix libcartographer_rviz.so.

### DIFF
--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -66,8 +66,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC cartographer)
-
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   "${EIGEN3_INCLUDE_DIR}")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${EIGEN3_LIBRARIES})
@@ -83,6 +81,8 @@ add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 set(TARGET_COMPILE_FLAGS "${TARGET_COMPILE_FLAGS} ${GOOG_CXX_FLAGS}")
 set_target_properties(${PROJECT_NAME} PROPERTIES
   COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC cartographer)
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
This fixes the issue that rviz crashes when loading the cartographer_rviz plugin saying that the symbol `cartographer::io::UnpackTextureData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int)` is undefined.

PAIR=@wohe,@SirVer
  