### PR TITLE
Enable publishing all bag messages in offline node

### DIFF
--- a/cartographer_ros/cartographer_ros/playable_bag.cc
+++ b/cartographer_ros/cartographer_ros/playable_bag.cc
@@ -126,4 +126,8 @@ PlayableBagMultiplexer::GetNextMessage() {
                          !current_bag.IsMessageAvailable());
 }
 
+std::vector<const rosbag::ConnectionInfo*> PlayableBag::GetConnections() {
+  return view_->getConnections();
+}
+
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/playable_bag.h
+++ b/cartographer_ros/cartographer_ros/playable_bag.h
@@ -41,6 +41,7 @@ class PlayableBag {
   rosbag::MessageInstance GetNextMessage();
   bool IsMessageAvailable();
   std::tuple<ros::Time, ros::Time> GetBeginEndTime();
+  std::vector<const rosbag::ConnectionInfo*> GetConnections();
 
   int bag_id();
 


### PR DESCRIPTION
This introduces an option called 'publish_all_bag_messages' which publishes everything from the bag as the offline node processes it. For example, if there is a camera on the robot, the images from the camera topic can be watched if the option is enabled, since the offline node will publish all messages from the bag (just like rosbag play).