### PR TITLE
Use standalone GMock, fix docker builds.

### DIFF
--- a/Dockerfile.kinetic
+++ b/Dockerfile.kinetic
@@ -44,29 +44,29 @@ RUN /catkin_ws/src/cartographer/scripts/install_proto3.sh
 # Build, install, and test all packages individually to allow caching. The
 # ordering of these steps must match the topological package ordering as
 # determined by Catkin.
-COPY scripts/install.sh cartographer_ros/scripts/
+COPY scripts/install-ninja.sh cartographer_ros/scripts/
 COPY scripts/catkin_test_results.sh cartographer_ros/scripts/
 
 COPY cartographer_ros_msgs catkin_ws/src/cartographer_ros/cartographer_ros_msgs/
-RUN cartographer_ros/scripts/install.sh --pkg cartographer_ros_msgs && \
-    cartographer_ros/scripts/install.sh --pkg cartographer_ros_msgs \
+RUN cartographer_ros/scripts/install-ninja.sh --pkg cartographer_ros_msgs && \
+    cartographer_ros/scripts/install-ninja.sh --pkg cartographer_ros_msgs \
         --catkin-make-args run_tests && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_ros_msgs
 
-RUN cartographer_ros/scripts/install.sh --pkg ceres-solver
+RUN cartographer_ros/scripts/install-ninja.sh --pkg ceres-solver
 
-RUN cartographer_ros/scripts/install.sh --pkg cartographer && \
-    cartographer_ros/scripts/install.sh --pkg cartographer --make-args test
+RUN cartographer_ros/scripts/install-ninja.sh --pkg cartographer && \
+    cartographer_ros/scripts/install-ninja.sh --pkg cartographer --make-args test
 
 COPY cartographer_ros catkin_ws/src/cartographer_ros/cartographer_ros/
-RUN cartographer_ros/scripts/install.sh --pkg cartographer_ros && \
-    cartographer_ros/scripts/install.sh --pkg cartographer_ros \
+RUN cartographer_ros/scripts/install-ninja.sh --pkg cartographer_ros && \
+    cartographer_ros/scripts/install-ninja.sh --pkg cartographer_ros \
         --catkin-make-args run_tests && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_ros
 
 COPY cartographer_rviz catkin_ws/src/cartographer_ros/cartographer_rviz/
-RUN cartographer_ros/scripts/install.sh --pkg cartographer_rviz && \
-    cartographer_ros/scripts/install.sh --pkg cartographer_rviz \
+RUN cartographer_ros/scripts/install-ninja.sh --pkg cartographer_rviz && \
+    cartographer_ros/scripts/install-ninja.sh --pkg cartographer_rviz \
         --catkin-make-args run_tests && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_rviz
 

--- a/Dockerfile.lunar
+++ b/Dockerfile.lunar
@@ -44,29 +44,29 @@ RUN /catkin_ws/src/cartographer/scripts/install_proto3.sh
 # Build, install, and test all packages individually to allow caching. The
 # ordering of these steps must match the topological package ordering as
 # determined by Catkin.
-COPY scripts/install.sh cartographer_ros/scripts/
+COPY scripts/install-ninja.sh cartographer_ros/scripts/
 COPY scripts/catkin_test_results.sh cartographer_ros/scripts/
 
 COPY cartographer_ros_msgs catkin_ws/src/cartographer_ros/cartographer_ros_msgs/
-RUN cartographer_ros/scripts/install.sh --pkg cartographer_ros_msgs && \
-    cartographer_ros/scripts/install.sh --pkg cartographer_ros_msgs \
+RUN cartographer_ros/scripts/install-ninja.sh --pkg cartographer_ros_msgs && \
+    cartographer_ros/scripts/install-ninja.sh --pkg cartographer_ros_msgs \
         --catkin-make-args run_tests && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_ros_msgs
 
-RUN cartographer_ros/scripts/install.sh --pkg ceres-solver
+RUN cartographer_ros/scripts/install-ninja.sh --pkg ceres-solver
 
-RUN cartographer_ros/scripts/install.sh --pkg cartographer && \
-    cartographer_ros/scripts/install.sh --pkg cartographer --make-args test
+RUN cartographer_ros/scripts/install-ninja.sh --pkg cartographer && \
+    cartographer_ros/scripts/install-ninja.sh --pkg cartographer --make-args test
 
 COPY cartographer_ros catkin_ws/src/cartographer_ros/cartographer_ros/
-RUN cartographer_ros/scripts/install.sh --pkg cartographer_ros && \
-    cartographer_ros/scripts/install.sh --pkg cartographer_ros \
+RUN cartographer_ros/scripts/install-ninja.sh --pkg cartographer_ros && \
+    cartographer_ros/scripts/install-ninja.sh --pkg cartographer_ros \
         --catkin-make-args run_tests && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_ros
 
 COPY cartographer_rviz catkin_ws/src/cartographer_ros/cartographer_rviz/
-RUN cartographer_ros/scripts/install.sh --pkg cartographer_rviz && \
-    cartographer_ros/scripts/install.sh --pkg cartographer_rviz \
+RUN cartographer_ros/scripts/install-ninja.sh --pkg cartographer_rviz && \
+    cartographer_ros/scripts/install-ninja.sh --pkg cartographer_rviz \
         --catkin-make-args run_tests && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_rviz
 

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -40,7 +40,6 @@ include("${CARTOGRAPHER_CMAKE_DIR}/functions.cmake")
 set(BUILD_SHARED_LIBS OFF)
 option(BUILD_GRPC "build features that require Cartographer gRPC support" false)
 google_initialize_cartographer_project()
-google_enable_testing()
 
 find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
 
@@ -61,11 +60,6 @@ endif()
 include_directories(
   ${urdfdom_headers_INCLUDE_DIRS}
 )
-
-# Override Catkin's GTest configuration to use GMock.
-set(GTEST_FOUND TRUE)
-set(GTEST_INCLUDE_DIRS ${GMOCK_INCLUDE_DIRS})
-set(GTEST_LIBRARIES ${GMOCK_LIBRARIES})
 
 catkin_package(
   CATKIN_DEPENDS
@@ -134,6 +128,7 @@ set(TARGET_COMPILE_FLAGS "${TARGET_COMPILE_FLAGS} ${GOOG_CXX_FLAGS}")
 set_target_properties(${PROJECT_NAME} PROPERTIES
   COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
 
+google_enable_testing()
 if (CATKIN_ENABLE_TESTING)
   foreach(TEST_SOURCE_FILENAME ${ALL_TESTS})
     get_filename_component(TEST_NAME ${TEST_SOURCE_FILENAME} NAME_WE)
@@ -146,6 +141,7 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(${TEST_NAME} ${catkin_LIBRARIES})
     add_dependencies(${TEST_NAME} ${catkin_EXPORTED_TARGETS})
     target_link_libraries(${TEST_NAME} cartographer)
+    target_link_libraries(${TEST_NAME} standalone_gmock_main)
     target_link_libraries(${TEST_NAME} ${PROJECT_NAME})
     set_target_properties(${TEST_NAME} PROPERTIES COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
   endforeach()

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -40,6 +40,7 @@ include("${CARTOGRAPHER_CMAKE_DIR}/functions.cmake")
 set(BUILD_SHARED_LIBS OFF)
 option(BUILD_GRPC "build features that require Cartographer gRPC support" false)
 google_initialize_cartographer_project()
+google_enable_testing()
 
 find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
 
@@ -60,6 +61,11 @@ endif()
 include_directories(
   ${urdfdom_headers_INCLUDE_DIRS}
 )
+
+# Override Catkin's GTest configuration to use our GMock.
+set(GTEST_FOUND TRUE)
+set(GTEST_INCLUDE_DIRS "")
+set(GTEST_LIBRARIES standalone_gmock_main)
 
 catkin_package(
   CATKIN_DEPENDS
@@ -128,7 +134,6 @@ set(TARGET_COMPILE_FLAGS "${TARGET_COMPILE_FLAGS} ${GOOG_CXX_FLAGS}")
 set_target_properties(${PROJECT_NAME} PROPERTIES
   COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
 
-google_enable_testing()
 if (CATKIN_ENABLE_TESTING)
   foreach(TEST_SOURCE_FILENAME ${ALL_TESTS})
     get_filename_component(TEST_NAME ${TEST_SOURCE_FILENAME} NAME_WE)

--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -32,7 +32,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>google-mock</build_depend>
   <build_depend>g++-static</build_depend>
   <build_depend>protobuf-dev</build_depend>
   <build_depend>python-sphinx</build_depend>
@@ -59,8 +58,6 @@
   <depend>tf2_ros</depend>
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
-
-  <test_depend>rosunit</test_depend>
 
   <export>
       <rviz plugin="${prefix}/rviz_plugin_description.xml" />

--- a/scripts/install-ninja.sh
+++ b/scripts/install-ninja.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2018 The Cartographer Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o verbose
+
+. /opt/ros/${ROS_DISTRO}/setup.sh
+
+cd catkin_ws
+
+# Build, install, and test.
+#
+# It's necessary to use the '--install' flag for every call to
+# 'catkin_make_isolated' in order to avoid the use of 'devel_isolated' as the
+# 'CMAKE_INSTALL_PREFIX' for non-test targets. This in itself is important to
+# avoid any issues caused by using 'CMAKE_INSTALL_PREFIX' during the
+# configuration phase of the build (e.g. cartographer/common/config.h.cmake).
+export BUILD_FLAGS="--use-ninja --install-space /opt/cartographer_ros --install"
+catkin_make_isolated ${BUILD_FLAGS} $@

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,5 +28,5 @@ cd catkin_ws
 # 'CMAKE_INSTALL_PREFIX' for non-test targets. This in itself is important to
 # avoid any issues caused by using 'CMAKE_INSTALL_PREFIX' during the
 # configuration phase of the build (e.g. cartographer/common/config.h.cmake).
-export BUILD_FLAGS="--use-ninja --install-space /opt/cartographer_ros --install"
+export BUILD_FLAGS="--install-space /opt/cartographer_ros --install"
 catkin_make_isolated ${BUILD_FLAGS} $@


### PR DESCRIPTION
Fixes the GMock issue for all Docker builds.
This the follow up for https://github.com/googlecartographer/cartographer/pull/1017.

FIXES=#776