### PR TITLE
[cartographer_ros_msgs] add run dependency on message_runtime

### DIFF
--- a/cartographer_ros_msgs/CMakeLists.txt
+++ b/cartographer_ros_msgs/CMakeLists.txt
@@ -51,4 +51,5 @@ generate_messages(
 catkin_package(
   CATKIN_DEPENDS
     ${PACKAGE_DEPENDENCIES}
+    message_runtime
 )

--- a/cartographer_ros_msgs/package.xml
+++ b/cartographer_ros_msgs/package.xml
@@ -33,4 +33,6 @@
   <depend>geometry_msgs</depend>
 
   <build_depend>message_generation</build_depend>
+  
+  <exec_depend>message_runtime</exec_depend>
 </package>


### PR DESCRIPTION
As per ROS [tutorials](http://wiki.ros.org/ROS/Tutorials/DefiningCustomMessages#Dependencies)

Edit: For future readers, the linked tutorial was referring to `run_depend` from package format 1 as pointed out by @ojura, it has now been updated to refer to `exec_depend` from format 2