### PR TITLE
Enable rendering of submaps without a grid

### DIFF
--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -178,9 +178,6 @@ void MapBuilderBridge::HandleSubmapQuery(
     return;
   }
 
-  CHECK(response_proto.textures_size() > 0)
-      << "empty textures given for submap: " << submap_id;
-
   response.submap_version = response_proto.submap_version();
   for (const auto& texture_proto : response_proto.textures()) {
     response.textures.emplace_back();

--- a/cartographer_ros/cartographer_ros/submap.cc
+++ b/cartographer_ros/cartographer_ros/submap.cc
@@ -33,7 +33,10 @@ std::unique_ptr<::cartographer::io::SubmapTextures> FetchSubmapTextures(
   if (!client->call(srv)) {
     return nullptr;
   }
-  CHECK(!srv.response.textures.empty());
+  //CHECK(!srv.response.textures.empty());
+  if (srv.response.textures.empty()) {
+    return nullptr;
+  }
   auto response =
       ::cartographer::common::make_unique<::cartographer::io::SubmapTextures>();
   response->version = srv.response.submap_version;


### PR DESCRIPTION
- related to https://github.com/googlecartographer/cartographer_ros/issues/819