### PR TITLE
Getter for trajectories in AssetsWriter

### DIFF
--- a/cartographer_ros/cartographer_ros/assets_writer.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer.cc
@@ -66,8 +66,7 @@ std::unique_ptr<carto::io::PointsProcessorPipelineBuilder>
 CreatePipelineBuilder(
     const std::vector<carto::mapping::proto::Trajectory>& trajectories,
     const std::string file_prefix) {
-  const auto file_writer_factory =
-      AssetsWriter::CreateFileWriterFactory(file_prefix);
+  const auto file_writer_factory = CreateFileWriterFactory(file_prefix);
   auto builder =
       carto::common::make_unique<carto::io::PointsProcessorPipelineBuilder>();
   carto::io::RegisterBuiltInPointsProcessors(trajectories, file_writer_factory,
@@ -267,7 +266,7 @@ void AssetsWriter::Run(const std::string& configuration_directory,
            carto::io::PointsProcessor::FlushResult::kRestartStream);
 }
 
-::cartographer::io::FileWriterFactory AssetsWriter::CreateFileWriterFactory(
+::cartographer::io::FileWriterFactory CreateFileWriterFactory(
     const std::string& file_path) {
   const auto file_writer_factory = [file_path](const std::string& filename) {
     return carto::common::make_unique<carto::io::StreamFileWriter>(file_path +

--- a/cartographer_ros/cartographer_ros/assets_writer.h
+++ b/cartographer_ros/cartographer_ros/assets_writer.h
@@ -46,9 +46,11 @@ class AssetsWriter {
            const std::string& configuration_basename,
            const std::string& urdf_filename, bool use_bag_transforms);
 
-  // Creates a FileWriterFactory which creates a FileWriter for storing assets.
-  static ::cartographer::io::FileWriterFactory CreateFileWriterFactory(
-      const std::string& file_path);
+  // Returns all trajectories of the pose graph.
+  const std::vector<::cartographer::mapping::proto::Trajectory>& trajectories()
+      const {
+    return all_trajectories_;
+  }
 
  private:
   std::vector<std::string> bag_filenames_;
@@ -57,6 +59,10 @@ class AssetsWriter {
   std::unique_ptr<::cartographer::io::PointsProcessorPipelineBuilder>
       point_pipeline_builder_;
 };
+
+// Creates a FileWriterFactory which creates a FileWriter for storing assets.
+::cartographer::io::FileWriterFactory CreateFileWriterFactory(
+    const std::string& file_path);
 
 }  // namespace cartographer_ros
 


### PR DESCRIPTION
Added a getter for the trajectories of the pose graph to the AssetsWriter and moved CreateFileWriterFactory outside of the AssetsWriter class.

To register new points processors, PointsProcessors need to be constructed from outside the AssetsWriter. This may require the trajectories of the pose graph. Therefore, the getter for the trajectories was added to the AssetsWriter.

The static class method CreateFileWriterFactory was moved outside the AssetsWriter to communicate its independence of class internals of the AssetsWriter.