### PR TITLE
Use immediately invoked lambda for tracking_to_local.

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -221,9 +221,8 @@ void Node::PublishTrajectoryStates(const ::ros::WallTimerEvent& timer_event) {
       if (trajectory_state.trajectory_options.publish_frame_projected_to_2d) {
         return carto::transform::Embed3D(
             carto::transform::Project2D(extrapolator.ExtrapolatePose(now)));
-      } else {
-        return extrapolator.ExtrapolatePose(now);
       }
+      return extrapolator.ExtrapolatePose(now);
     }();
 
     const Rigid3d tracking_to_map =

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -217,11 +217,14 @@ void Node::PublishTrajectoryStates(const ::ros::WallTimerEvent& timer_event) {
         FromRos(ros::Time::now()), extrapolator.GetLastExtrapolatedTime());
     stamped_transform.header.stamp = ToRos(now);
 
-    Rigid3d tracking_to_local = extrapolator.ExtrapolatePose(now);
-    if (trajectory_state.trajectory_options.publish_frame_projected_to_2d) {
-      tracking_to_local = carto::transform::Embed3D(
-          carto::transform::Project2D(tracking_to_local));
-    }
+    const Rigid3d tracking_to_local = [&] {
+      if (trajectory_state.trajectory_options.publish_frame_projected_to_2d) {
+        return carto::transform::Embed3D(
+            carto::transform::Project2D(extrapolator.ExtrapolatePose(now)));
+      } else {
+        return extrapolator.ExtrapolatePose(now);
+      }
+    }();
 
     const Rigid3d tracking_to_map =
         trajectory_state.local_to_map * tracking_to_local;


### PR DESCRIPTION
Restores const-correctness that we dropped when introducing the 
`publish_frame_projected_to_2d` param without using a ternary operator.