### PR TITLE
Fix the 'load_frozen_state' flag in visualize_pbstream.launch.

### DIFF
--- a/cartographer_ros/launch/visualize_pbstream.launch
+++ b/cartographer_ros/launch/visualize_pbstream.launch
@@ -21,9 +21,9 @@
       type="cartographer_offline_node" args="
           -configuration_directory $(find cartographer_ros)/configuration_files
           -configuration_basenames visualize_pbstream.lua
-          -keep_running true
+          -keep_running=true
           -load_state_filename $(arg pbstream_filename)
-          -load_frozen_state false"
+          -load_frozen_state=false"
       output="screen">
   </node>
 </launch>


### PR DESCRIPTION
Since "-load_frozen_state" is a bool flag, "-load_frozen_state false" works like "-load_frozen_state", i.e. true.