### PR TITLE
Assets writer (ROS map) urdf typo fix

### DIFF
--- a/cartographer_ros/launch/assets_writer_ros_map.launch
+++ b/cartographer_ros/launch/assets_writer_ros_map.launch
@@ -19,7 +19,7 @@
 -->
 
 <launch>
-  <arg name="urdf_filename" default="$(find cartographer_ros)/urdf/backback_2d.urdf"/> 
+  <arg name="urdf_filename" default="$(find cartographer_ros)/urdf/backpack_2d.urdf"/>
 
   <node name="cartographer_assets_writer" pkg="cartographer_ros" required="true"
       type="cartographer_assets_writer" args="


### PR DESCRIPTION
The ROS map assets writer launch file can now find the default urdf file when no argument is provided.