### PR TITLE
Sanitize node memory consumption with a smaller TF buffer size.

### DIFF
--- a/cartographer_ros/cartographer_ros/cartographer_grpc/node_grpc_main.cc
+++ b/cartographer_ros/cartographer_ros/cartographer_grpc/node_grpc_main.cc
@@ -45,7 +45,7 @@ namespace cartographer_ros {
 namespace {
 
 void Run() {
-  constexpr double kTfBufferCacheTimeInSeconds = 1e6;
+  constexpr double kTfBufferCacheTimeInSeconds = 10.;
   tf2_ros::Buffer tf_buffer{::ros::Duration(kTfBufferCacheTimeInSeconds)};
   tf2_ros::TransformListener tf(tf_buffer);
   NodeOptions node_options;

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -39,15 +39,13 @@ DEFINE_bool(
 DEFINE_string(
     save_state_filename, "",
     "If non-empty, serialize state and write it to disk before shutting down.");
-DEFINE_double(tf_buffer_cache_time_seconds, 1e2,
-              "Determines the buffer length for caching TF.");
 
 namespace cartographer_ros {
 namespace {
 
 void Run() {
-  tf2_ros::Buffer tf_buffer{
-      ::ros::Duration(FLAGS_tf_buffer_cache_time_seconds)};
+  constexpr double kTfBufferCacheTimeInSeconds = 10.;
+  tf2_ros::Buffer tf_buffer{::ros::Duration(kTfBufferCacheTimeInSeconds)};
   tf2_ros::TransformListener tf(tf_buffer);
   NodeOptions node_options;
   TrajectoryOptions trajectory_options;

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -39,13 +39,16 @@ DEFINE_bool(
 DEFINE_string(
     save_state_filename, "",
     "If non-empty, serialize state and write it to disk before shutting down.");
+DEFINE_double(tf_buffer_cache_time_seconds, 1e2,
+              "Determines the buffer length for caching TF.")
 
 namespace cartographer_ros {
 namespace {
 
 void Run() {
   constexpr double kTfBufferCacheTimeInSeconds = 1e6;
-  tf2_ros::Buffer tf_buffer{::ros::Duration(kTfBufferCacheTimeInSeconds)};
+  tf2_ros::Buffer tf_buffer{
+      ::ros::Duration(FLAGS_tf_buffer_cache_time_seconds)};
   tf2_ros::TransformListener tf(tf_buffer);
   NodeOptions node_options;
   TrajectoryOptions trajectory_options;

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -46,7 +46,6 @@ namespace cartographer_ros {
 namespace {
 
 void Run() {
-  constexpr double kTfBufferCacheTimeInSeconds = 1e6;
   tf2_ros::Buffer tf_buffer{
       ::ros::Duration(FLAGS_tf_buffer_cache_time_seconds)};
   tf2_ros::TransformListener tf(tf_buffer);

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -40,7 +40,7 @@ DEFINE_string(
     save_state_filename, "",
     "If non-empty, serialize state and write it to disk before shutting down.");
 DEFINE_double(tf_buffer_cache_time_seconds, 1e2,
-              "Determines the buffer length for caching TF.")
+              "Determines the buffer length for caching TF.");
 
     namespace cartographer_ros {
   namespace {

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -42,42 +42,42 @@ DEFINE_string(
 DEFINE_double(tf_buffer_cache_time_seconds, 1e2,
               "Determines the buffer length for caching TF.");
 
-    namespace cartographer_ros {
-  namespace {
+namespace cartographer_ros {
+namespace {
 
-  void Run() {
-    constexpr double kTfBufferCacheTimeInSeconds = 1e6;
-    tf2_ros::Buffer tf_buffer{
-        ::ros::Duration(FLAGS_tf_buffer_cache_time_seconds)};
-    tf2_ros::TransformListener tf(tf_buffer);
-    NodeOptions node_options;
-    TrajectoryOptions trajectory_options;
-    std::tie(node_options, trajectory_options) = LoadOptions(
-        FLAGS_configuration_directory, FLAGS_configuration_basename);
+void Run() {
+  constexpr double kTfBufferCacheTimeInSeconds = 1e6;
+  tf2_ros::Buffer tf_buffer{
+      ::ros::Duration(FLAGS_tf_buffer_cache_time_seconds)};
+  tf2_ros::TransformListener tf(tf_buffer);
+  NodeOptions node_options;
+  TrajectoryOptions trajectory_options;
+  std::tie(node_options, trajectory_options) =
+      LoadOptions(FLAGS_configuration_directory, FLAGS_configuration_basename);
 
-    auto map_builder =
-        cartographer::common::make_unique<cartographer::mapping::MapBuilder>(
-            node_options.map_builder_options);
-    Node node(node_options, std::move(map_builder), &tf_buffer);
-    if (!FLAGS_load_state_filename.empty()) {
-      node.LoadState(FLAGS_load_state_filename, FLAGS_load_frozen_state);
-    }
-
-    if (FLAGS_start_trajectory_with_default_topics) {
-      node.StartTrajectoryWithDefaultTopics(trajectory_options);
-    }
-
-    ::ros::spin();
-
-    node.FinishAllTrajectories();
-    node.RunFinalOptimization();
-
-    if (!FLAGS_save_state_filename.empty()) {
-      node.SerializeState(FLAGS_save_state_filename);
-    }
+  auto map_builder =
+      cartographer::common::make_unique<cartographer::mapping::MapBuilder>(
+          node_options.map_builder_options);
+  Node node(node_options, std::move(map_builder), &tf_buffer);
+  if (!FLAGS_load_state_filename.empty()) {
+    node.LoadState(FLAGS_load_state_filename, FLAGS_load_frozen_state);
   }
 
-  }  // namespace
+  if (FLAGS_start_trajectory_with_default_topics) {
+    node.StartTrajectoryWithDefaultTopics(trajectory_options);
+  }
+
+  ::ros::spin();
+
+  node.FinishAllTrajectories();
+  node.RunFinalOptimization();
+
+  if (!FLAGS_save_state_filename.empty()) {
+    node.SerializeState(FLAGS_save_state_filename);
+  }
+}
+
+}  // namespace
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Fixes an (almost) unbounded growth of the TF buffer.

See the heap profile logs in the PR for more information.