### PR TITLE
[cartographer_ros_msgs] Message dependency fixup

### DIFF
--- a/cartographer_ros_msgs/CMakeLists.txt
+++ b/cartographer_ros_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ project(cartographer_ros_msgs)
 
 set(PACKAGE_DEPENDENCIES
   geometry_msgs
+  std_msgs
 )
 
 find_package(catkin REQUIRED COMPONENTS message_generation ${PACKAGE_DEPENDENCIES})
@@ -45,7 +46,7 @@ add_service_files(
 
 generate_messages(
   DEPENDENCIES
-    geometry_msgs
+    ${PACKAGE_DEPENDENCIES}
 )
 
 catkin_package(

--- a/cartographer_ros_msgs/msg/LandmarkList.msg
+++ b/cartographer_ros_msgs/msg/LandmarkList.msg
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 std_msgs/Header header
-LandmarkEntry[] landmark
+cartographer_ros_msgs/LandmarkEntry[] landmark

--- a/cartographer_ros_msgs/msg/SubmapList.msg
+++ b/cartographer_ros_msgs/msg/SubmapList.msg
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 std_msgs/Header header
-SubmapEntry[] submap
+cartographer_ros_msgs/SubmapEntry[] submap

--- a/cartographer_ros_msgs/package.xml
+++ b/cartographer_ros_msgs/package.xml
@@ -31,6 +31,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
   <build_depend>message_generation</build_depend>
   

--- a/cartographer_ros_msgs/srv/SubmapQuery.srv
+++ b/cartographer_ros_msgs/srv/SubmapQuery.srv
@@ -17,4 +17,4 @@ int32 submap_index
 ---
 cartographer_ros_msgs/StatusResponse status
 int32 submap_version
-SubmapTexture[] textures
+cartographer_ros_msgs/SubmapTexture[] textures


### PR DESCRIPTION
First commit adds the missing dependency on `std_msgs` as several messages use `std_msgs/Header`
Second commit homogenize the way messages reference each other and use the absolute `<MESSAGE_PACKAGE>/<MESSAGE_NAME>` everywhere (note that the relative reference is just as correct, I just picked one to be consistent) 