### PR TITLE
remove architecture specific definitions exported by PCL

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -104,7 +104,13 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
 # PCL
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${PCL_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PCL_LIBRARIES})
+
+set(_blacklisted_definitions " -march=native -msse4.2 -mfpmath=sse ")
 foreach(DEFINITION ${PCL_DEFINITIONS})
+  list (FIND _blacklisted_definitions "${DEFINITION}" _index)
+  if (${_index} GREATER -1)
+    continue()
+  endif()
   set(TARGET_COMPILE_FLAGS "${TARGET_COMPILE_FLAGS} ${DEFINITION}")
 endforeach()
 


### PR DESCRIPTION
This is an issue on PCL 1.8.X causing SIGILL, Illegal instruction crashes: https://github.com/ros-gbp/cartographer_ros-release/issues/10
Should be fixed in future PCL version with https://github.com/PointCloudLibrary/pcl/pull/2100

Note: `PCL_DEFINITIONS` doesn't contain anything else than the unwanted definition on bionic. I kept the logic as is in case adding the definitions was needed on other platforms.
Note2: while right now there is a single blacklisted definition, I made it a list in case we need to add more in the future