### PR TITLE
Simplify gauge and histogram implementation.

### DIFF
--- a/cartographer_ros/cartographer_ros/metrics/internal/counter.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/counter.h
@@ -29,7 +29,7 @@ class Counter : public ::cartographer::metrics::Counter {
   explicit Counter(const std::map<std::string, std::string>& labels)
       : gauge_(labels) {}
 
-  void Increment(const double by_value) override { gauge_.Increment(by_value); }
+  void Increment(const double value) override { gauge_.Increment(value); }
 
   void Increment() override { gauge_.Increment(); }
 

--- a/cartographer_ros/cartographer_ros/metrics/internal/counter.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/counter.h
@@ -33,7 +33,7 @@ class Counter : public ::cartographer::metrics::Counter {
 
   void Increment() override { gauge_.Increment(); }
 
-  double Value() const { return gauge_.Value(); }
+  double Value() { return gauge_.Value(); }
 
   cartographer_ros_msgs::Metric ToRosMessage() {
     cartographer_ros_msgs::Metric msg = gauge_.ToRosMessage();

--- a/cartographer_ros/cartographer_ros/metrics/internal/family.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/family.h
@@ -62,7 +62,7 @@ class HistogramFamily : public ::cartographer::metrics::Family<
  public:
   HistogramFamily(const std::string& name, const std::string& description,
                   const BucketBoundaries& boundaries)
-      : boundaries_(boundaries) {}
+      : name_(name), description_(description), boundaries_(boundaries) {}
 
   Histogram* Add(const std::map<std::string, std::string>& labels) override;
 

--- a/cartographer_ros/cartographer_ros/metrics/internal/gauge.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/gauge.h
@@ -44,6 +44,7 @@ class Gauge : public ::cartographer::metrics::Gauge {
     ::cartographer::common::MutexLocker lock(&mutex_);
     value_ = value;
   }
+
   double Value() {
     ::cartographer::common::MutexLocker lock(&mutex_);
     return value_;

--- a/cartographer_ros/cartographer_ros/metrics/internal/histogram.cc
+++ b/cartographer_ros/cartographer_ros/metrics/internal/histogram.cc
@@ -36,9 +36,6 @@ Histogram::Histogram(const std::map<std::string, std::string>& labels,
                        std::end(bucket_boundaries_)));
 }
 
-Histogram::Histogram(const BucketBoundaries& bucket_boundaries)
-    : Histogram({}, bucket_boundaries) {}
-
 void Histogram::Observe(double value) {
   auto bucket_index =
       std::distance(bucket_boundaries_.begin(),

--- a/cartographer_ros/cartographer_ros/metrics/internal/histogram.cc
+++ b/cartographer_ros/cartographer_ros/metrics/internal/histogram.cc
@@ -44,7 +44,6 @@ void Histogram::Observe(double value) {
       std::distance(bucket_boundaries_.begin(),
                     std::upper_bound(bucket_boundaries_.begin(),
                                      bucket_boundaries_.end(), value));
-  // TODO: check lock contention and potential for atomic operations.
   ::cartographer::common::MutexLocker lock(&mutex_);
   sum_ += value;
   bucket_counts_[bucket_index] += 1;

--- a/cartographer_ros/cartographer_ros/metrics/internal/histogram.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/histogram.h
@@ -36,8 +36,6 @@ class Histogram : public ::cartographer::metrics::Histogram {
   explicit Histogram(const std::map<std::string, std::string>& labels,
                      const BucketBoundaries& bucket_boundaries);
 
-  explicit Histogram(const BucketBoundaries& bucket_boundaries);
-
   void Observe(double value) override;
 
   std::map<double, double> CountsByBucket();

--- a/cartographer_ros/cartographer_ros/metrics/internal/metrics_test.cc
+++ b/cartographer_ros/cartographer_ros/metrics/internal/metrics_test.cc
@@ -78,7 +78,7 @@ TEST(Metrics, HistogramFixedWidthTest) {
 TEST(Metrics, HistogramScaledPowersOfTest) {
   auto boundaries =
       ::cartographer::metrics::Histogram::ScaledPowersOf(2, 1, 2048);
-  Histogram histogram(boundaries);
+  Histogram histogram({}, boundaries);
 
   // Observe some values that fit in finite buckets.
   std::array<double, 3> values = {{256, 512, 666}};

--- a/cartographer_ros/cartographer_ros/metrics/internal/metrics_test.cc
+++ b/cartographer_ros/cartographer_ros/metrics/internal/metrics_test.cc
@@ -53,7 +53,7 @@ TEST(Metrics, CounterTest) {
 
 TEST(Metrics, HistogramFixedWidthTest) {
   auto boundaries = ::cartographer::metrics::Histogram::FixedWidth(1, 3);
-  Histogram histogram(boundaries);
+  Histogram histogram({}, boundaries);
 
   // Observe some values that fit in finite buckets.
   std::array<double, 3> values = {{0., 2, 2.5}};


### PR DESCRIPTION
Use a mutex locker instead of atomic operations in gauge.

Remove unnecessary constructor overload from histogram.