### PR TITLE
Fix bug in FinishTrajectory logic

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -466,6 +466,7 @@ cartographer_ros_msgs::StatusResponse Node::FinishTrajectoryUnderLock(
     status_response.code = cartographer_ros_msgs::StatusCode::OK;
     status_response.message = message;
     LOG(INFO) << message;
+    return status_response;
   }
 
   // First, check if we can actually finish the trajectory.

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -213,6 +213,7 @@ class Node {
   std::unordered_map<int, TrajectorySensorSamplers> sensor_samplers_;
   std::unordered_map<int, std::vector<Subscriber>> subscribers_;
   std::unordered_set<std::string> subscribed_topics_;
+  std::unordered_set<int> trajectories_scheduled_for_finish_;
 
   // We have to keep the timer handles of ::ros::WallTimers around, otherwise
   // they do not fire.


### PR DESCRIPTION
This PR adds additional bookkeeping for trajectories that we scheduled for
finishing.

In Node::RunFinalOptimization(...), we were calling FinishTrajectory for
every active trajectory (state == ACTIVE). Since the state only gets updated
once the corresponding worker for the FinishTrajectory task is
scheduled, we were potentially calling FinishTrajectory twice for a
single trajectory id.

Reproducible on master e.g. with 
```
roslaunch cartographer_ros offline_backpack_2d.launch bag_filenames:=b2-2016-02-02-14-01-56.bag no_rviz:=true
```