### PR TITLE
Allow zero pose_publish_period

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -131,9 +131,11 @@ Node::Node(
   wall_timers_.push_back(node_handle_.createWallTimer(
       ::ros::WallDuration(node_options_.submap_publish_period_sec),
       &Node::PublishSubmapList, this));
-  publish_local_trajectory_data_timer_ = node_handle_.createTimer(
-      ::ros::Duration(node_options_.pose_publish_period_sec),
-      &Node::PublishLocalTrajectoryData, this);
+  if (node_options_.pose_publish_period_sec > 0) {
+    publish_local_trajectory_data_timer_ = node_handle_.createTimer(
+        ::ros::Duration(node_options_.pose_publish_period_sec),
+        &Node::PublishLocalTrajectoryData, this);
+  }
   wall_timers_.push_back(node_handle_.createWallTimer(
       ::ros::WallDuration(node_options_.trajectory_publish_period_sec),
       &Node::PublishTrajectoryNodeList, this));


### PR DESCRIPTION
To compare different SLAM software online, it is necessary to
disable tf broadcast.
Because we already have a parameter "pose_publish_period_sec",
we use a zero value here to turn off tf broadcast.