### PR TITLE
Add .clang-format file.

### DIFF
--- a/cartographer_ros/cartographer_ros/.clang-format
+++ b/cartographer_ros/cartographer_ros/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+DerivePointerAlignment: false

--- a/cartographer_rviz/cartographer_rviz/.clang-format
+++ b/cartographer_rviz/cartographer_rviz/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+DerivePointerAlignment: false


### PR DESCRIPTION
This adds a .clang-format file, so that git clang-format uses
Google style without the need to remember the commandline flag.
Similar to googlecartographer/cartographer#1249.