### PR TITLE
feat: Publish progress of processing the bagfile

### DIFF
--- a/cartographer_ros/cartographer_ros/playable_bag.cc
+++ b/cartographer_ros/cartographer_ros/playable_bag.cc
@@ -112,7 +112,7 @@ void PlayableBag::AdvanceUntilMessageAvailable() {
 PlayableBagMultiplexer::PlayableBagMultiplexer() : pnh_("~") {
   bag_progress_pub_ = pnh_.advertise<cartographer_ros_msgs::BagfileProgress>(
       "bagfile_progress", 10);
-  progress_pub_rate_ = pnh_.param("bagfile_progress_pub_rate", 10.0);
+  progress_pub_interval_ = pnh_.param("bagfile_progress_pub_interval", 10.0);
 }
 
 void PlayableBagMultiplexer::AddPlayableBag(PlayableBag playable_bag) {
@@ -138,7 +138,7 @@ PlayableBagMultiplexer::GetNextMessage() {
   cartographer_ros_msgs::BagfileProgress progress;
   rosbag::MessageInstance msg = current_bag.GetNextMessage(progress);
   if (ros::Time::now() - last_progress_pub_time_ >=
-      ros::Duration(progress_pub_rate_)) {
+      ros::Duration(progress_pub_interval_)) {
     progress.total_bagfiles = playable_bags_.size();
     bag_progress_pub_.publish(progress);
     last_progress_pub_time_ = ros::Time::now();

--- a/cartographer_ros/cartographer_ros/playable_bag.cc
+++ b/cartographer_ros/cartographer_ros/playable_bag.cc
@@ -57,16 +57,25 @@ std::tuple<ros::Time, ros::Time> PlayableBag::GetBeginEndTime() const {
   return std::make_tuple(view_->getBeginTime(), view_->getEndTime());
 }
 
-rosbag::MessageInstance PlayableBag::GetNextMessage() {
+rosbag::MessageInstance PlayableBag::GetNextMessage
+    (cartographer_ros_msgs::BagfileProgress &progress) {
   CHECK(IsMessageAvailable());
   const rosbag::MessageInstance msg = buffered_messages_.front();
   buffered_messages_.pop_front();
   AdvanceUntilMessageAvailable();
+  double processed_seconds = (msg.getTime() - view_->getBeginTime()).toSec();
   if ((log_counter_++ % 10000) == 0) {
-    LOG(INFO) << "Processed " << (msg.getTime() - view_->getBeginTime()).toSec()
-              << " of " << duration_in_seconds_ << " seconds of bag "
-              << bag_filename_;
+    LOG(INFO) << "Processed " << processed_seconds << " of " <<
+              duration_in_seconds_ << " seconds of bag " << bag_filename_;
   }
+  progress.bagfile_name = bag_filename_;
+  progress.bagfile_id = bag_id_;
+  progress.total_messages = view_->size();
+  progress.processed_messages = std::distance(view_->begin(),
+                                              view_iterator_);
+  progress.total_seconds = duration_in_seconds_;
+  progress.processed_seconds = processed_seconds;
+
   return msg;
 }
 
@@ -101,6 +110,13 @@ void PlayableBag::AdvanceUntilMessageAvailable() {
   } while (!finished_ && !IsMessageAvailable());
 }
 
+PlayableBagMultiplexer::PlayableBagMultiplexer():pnh_("~")
+{
+  bag_progress_pub_ = pnh_.advertise<cartographer_ros_msgs::BagfileProgress>(
+    "bagfile_progress", 10);
+  progress_pub_rate_ = pnh_.param("bagfile_progress_pub_rate", 10.0);
+}
+
 void PlayableBagMultiplexer::AddPlayableBag(PlayableBag playable_bag) {
   for (const auto& topic : playable_bag.topics()) {
     topics_.insert(topic);
@@ -121,7 +137,15 @@ PlayableBagMultiplexer::GetNextMessage() {
   CHECK(IsMessageAvailable());
   const int current_bag_index = next_message_queue_.top().bag_index;
   PlayableBag& current_bag = playable_bags_.at(current_bag_index);
-  rosbag::MessageInstance msg = current_bag.GetNextMessage();
+  cartographer_ros_msgs::BagfileProgress progress;
+  rosbag::MessageInstance msg = current_bag.GetNextMessage(progress);
+  if(ros::Time::now() - last_progress_pub_time_ >=
+      ros::Duration(progress_pub_rate_))
+  {
+    progress.total_bagfiles = playable_bags_.size();
+    bag_progress_pub_.publish(progress);
+    last_progress_pub_time_ = ros::Time::now();
+  }
   CHECK_EQ(msg.getTime(), next_message_queue_.top().message_timestamp);
   next_message_queue_.pop();
   if (current_bag.IsMessageAvailable()) {

--- a/cartographer_ros/cartographer_ros/playable_bag.cc
+++ b/cartographer_ros/cartographer_ros/playable_bag.cc
@@ -57,22 +57,21 @@ std::tuple<ros::Time, ros::Time> PlayableBag::GetBeginEndTime() const {
   return std::make_tuple(view_->getBeginTime(), view_->getEndTime());
 }
 
-rosbag::MessageInstance PlayableBag::GetNextMessage
-    (cartographer_ros_msgs::BagfileProgress &progress) {
+rosbag::MessageInstance PlayableBag::GetNextMessage(
+    cartographer_ros_msgs::BagfileProgress& progress) {
   CHECK(IsMessageAvailable());
   const rosbag::MessageInstance msg = buffered_messages_.front();
   buffered_messages_.pop_front();
   AdvanceUntilMessageAvailable();
   double processed_seconds = (msg.getTime() - view_->getBeginTime()).toSec();
   if ((log_counter_++ % 10000) == 0) {
-    LOG(INFO) << "Processed " << processed_seconds << " of " <<
-              duration_in_seconds_ << " seconds of bag " << bag_filename_;
+    LOG(INFO) << "Processed " << processed_seconds << " of "
+              << duration_in_seconds_ << " seconds of bag " << bag_filename_;
   }
   progress.bagfile_name = bag_filename_;
   progress.bagfile_id = bag_id_;
   progress.total_messages = view_->size();
-  progress.processed_messages = std::distance(view_->begin(),
-                                              view_iterator_);
+  progress.processed_messages = std::distance(view_->begin(), view_iterator_);
   progress.total_seconds = duration_in_seconds_;
   progress.processed_seconds = processed_seconds;
 
@@ -110,10 +109,9 @@ void PlayableBag::AdvanceUntilMessageAvailable() {
   } while (!finished_ && !IsMessageAvailable());
 }
 
-PlayableBagMultiplexer::PlayableBagMultiplexer():pnh_("~")
-{
+PlayableBagMultiplexer::PlayableBagMultiplexer() : pnh_("~") {
   bag_progress_pub_ = pnh_.advertise<cartographer_ros_msgs::BagfileProgress>(
-    "bagfile_progress", 10);
+      "bagfile_progress", 10);
   progress_pub_rate_ = pnh_.param("bagfile_progress_pub_rate", 10.0);
 }
 
@@ -139,9 +137,8 @@ PlayableBagMultiplexer::GetNextMessage() {
   PlayableBag& current_bag = playable_bags_.at(current_bag_index);
   cartographer_ros_msgs::BagfileProgress progress;
   rosbag::MessageInstance msg = current_bag.GetNextMessage(progress);
-  if(ros::Time::now() - last_progress_pub_time_ >=
-      ros::Duration(progress_pub_rate_))
-  {
+  if (ros::Time::now() - last_progress_pub_time_ >=
+      ros::Duration(progress_pub_rate_)) {
     progress.total_bagfiles = playable_bags_.size();
     bag_progress_pub_.publish(progress);
     last_progress_pub_time_ = ros::Time::now();

--- a/cartographer_ros/cartographer_ros/playable_bag.cc
+++ b/cartographer_ros/cartographer_ros/playable_bag.cc
@@ -68,8 +68,8 @@ rosbag::MessageInstance PlayableBag::GetNextMessage(
     LOG(INFO) << "Processed " << processed_seconds << " of "
               << duration_in_seconds_ << " seconds of bag " << bag_filename_;
   }
-  progress.bagfile_name = bag_filename_;
-  progress.bagfile_id = bag_id_;
+  progress.current_bagfile_name = bag_filename_;
+  progress.current_bagfile_id = bag_id_;
   progress.total_messages = view_->size();
   progress.processed_messages = std::distance(view_->begin(), view_iterator_);
   progress.total_seconds = duration_in_seconds_;

--- a/cartographer_ros/cartographer_ros/playable_bag.cc
+++ b/cartographer_ros/cartographer_ros/playable_bag.cc
@@ -138,7 +138,7 @@ PlayableBagMultiplexer::GetNextMessage() {
   cartographer_ros_msgs::BagfileProgress progress;
   rosbag::MessageInstance msg = current_bag.GetNextMessage(progress);
   if (ros::Time::now() - last_progress_pub_time_ >=
-      ros::Duration(progress_pub_interval_) &&
+          ros::Duration(progress_pub_interval_) &&
       bag_progress_pub_.getNumSubscribers() > 0) {
     progress.total_bagfiles = playable_bags_.size();
     bag_progress_pub_.publish(progress);

--- a/cartographer_ros/cartographer_ros/playable_bag.cc
+++ b/cartographer_ros/cartographer_ros/playable_bag.cc
@@ -138,7 +138,8 @@ PlayableBagMultiplexer::GetNextMessage() {
   cartographer_ros_msgs::BagfileProgress progress;
   rosbag::MessageInstance msg = current_bag.GetNextMessage(progress);
   if (ros::Time::now() - last_progress_pub_time_ >=
-      ros::Duration(progress_pub_interval_)) {
+      ros::Duration(progress_pub_interval_) &&
+      bag_progress_pub_.getNumSubscribers() > 0) {
     progress.total_bagfiles = playable_bags_.size();
     bag_progress_pub_.publish(progress);
     last_progress_pub_time_ = ros::Time::now();

--- a/cartographer_ros/cartographer_ros/playable_bag.h
+++ b/cartographer_ros/cartographer_ros/playable_bag.h
@@ -41,7 +41,7 @@ class PlayableBag {
 
   ros::Time PeekMessageTime() const;
   rosbag::MessageInstance GetNextMessage(
-      cartographer_ros_msgs::BagfileProgress& progress);
+      cartographer_ros_msgs::BagfileProgress* progress);
   bool IsMessageAvailable() const;
   std::tuple<ros::Time, ros::Time> GetBeginEndTime() const;
 

--- a/cartographer_ros/cartographer_ros/playable_bag.h
+++ b/cartographer_ros/cartographer_ros/playable_bag.h
@@ -100,7 +100,7 @@ class PlayableBagMultiplexer {
   // Last time when the progress was published
   ros::Time last_progress_pub_time_;
   // The time interval of publishing bag-file(s) processing in seconds
-  double progress_pub_rate_;
+  double progress_pub_interval_;
 
   std::vector<PlayableBag> playable_bags_;
   std::priority_queue<BagMessageItem, std::vector<BagMessageItem>,

--- a/cartographer_ros/cartographer_ros/playable_bag.h
+++ b/cartographer_ros/cartographer_ros/playable_bag.h
@@ -19,11 +19,11 @@
 #include <functional>
 #include <queue>
 
+#include <cartographer_ros_msgs/BagfileProgress.h>
+#include <ros/node_handle.h>
 #include "rosbag/bag.h"
 #include "rosbag/view.h"
 #include "tf2_ros/buffer.h"
-#include <ros/node_handle.h>
-#include <cartographer_ros_msgs/BagfileProgress.h>
 
 namespace cartographer_ros {
 
@@ -40,8 +40,8 @@ class PlayableBag {
               FilteringEarlyMessageHandler filtering_early_message_handler);
 
   ros::Time PeekMessageTime() const;
-  rosbag::MessageInstance GetNextMessage
-      (cartographer_ros_msgs::BagfileProgress &progress);
+  rosbag::MessageInstance GetNextMessage(
+      cartographer_ros_msgs::BagfileProgress& progress);
   bool IsMessageAvailable() const;
   std::tuple<ros::Time, ros::Time> GetBeginEndTime() const;
 

--- a/cartographer_ros/cartographer_ros/playable_bag.h
+++ b/cartographer_ros/cartographer_ros/playable_bag.h
@@ -22,6 +22,8 @@
 #include "rosbag/bag.h"
 #include "rosbag/view.h"
 #include "tf2_ros/buffer.h"
+#include <ros/node_handle.h>
+#include <cartographer_ros_msgs/BagfileProgress.h>
 
 namespace cartographer_ros {
 
@@ -38,7 +40,8 @@ class PlayableBag {
               FilteringEarlyMessageHandler filtering_early_message_handler);
 
   ros::Time PeekMessageTime() const;
-  rosbag::MessageInstance GetNextMessage();
+  rosbag::MessageInstance GetNextMessage
+      (cartographer_ros_msgs::BagfileProgress &progress);
   bool IsMessageAvailable() const;
   std::tuple<ros::Time, ros::Time> GetBeginEndTime() const;
 
@@ -65,6 +68,7 @@ class PlayableBag {
 
 class PlayableBagMultiplexer {
  public:
+  PlayableBagMultiplexer();
   void AddPlayableBag(PlayableBag playable_bag);
 
   // Returns the next message from the multiplexed (merge-sorted) message
@@ -89,6 +93,14 @@ class PlayableBagMultiplexer {
       }
     };
   };
+
+  ros::NodeHandle pnh_;
+  // Publishes information about the bag-file(s) processing and its progress
+  ros::Publisher bag_progress_pub_;
+  // Last time when the progress was published
+  ros::Time last_progress_pub_time_;
+  // The time interval of publishing bag-file(s) processing in seconds
+  double progress_pub_rate_;
 
   std::vector<PlayableBag> playable_bags_;
   std::priority_queue<BagMessageItem, std::vector<BagMessageItem>,

--- a/cartographer_ros/cartographer_ros/playable_bag.h
+++ b/cartographer_ros/cartographer_ros/playable_bag.h
@@ -97,8 +97,8 @@ class PlayableBagMultiplexer {
   ros::NodeHandle pnh_;
   // Publishes information about the bag-file(s) processing and its progress
   ros::Publisher bag_progress_pub_;
-  // Last time when the progress was published
-  ros::Time last_progress_pub_time_;
+  // Map between bagfile id and the last time when its progress was published
+  std::map<int, ros::Time> bag_progress_time_map_;
   // The time interval of publishing bag-file(s) processing in seconds
   double progress_pub_interval_;
 

--- a/cartographer_ros_msgs/CMakeLists.txt
+++ b/cartographer_ros_msgs/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(catkin REQUIRED COMPONENTS message_generation ${PACKAGE_DEPENDENCIE
 add_message_files(
   DIRECTORY msg
   FILES
+    BagfileProgress.msg
     LandmarkEntry.msg
     LandmarkList.msg
     SensorTopics.msg

--- a/cartographer_ros_msgs/msg/BagfileProgress.msg
+++ b/cartographer_ros_msgs/msg/BagfileProgress.msg
@@ -1,0 +1,23 @@
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Contains general information about the bagfiles processing progress
+
+string current_bagfile_name
+uint32 current_bagfile_id
+uint32 total_bagfiles
+uint32 total_messages
+uint32 processed_messages
+float32 total_seconds
+float32 processed_seconds


### PR DESCRIPTION
## What I did
- Added a publisher which is publishing the progress of processing the bag-files
  - The message type is `cartographer_ros_msgs/BagfileProgress` which is added in this PR
    - It contains number of bagfiles in the queue, current bagfile name and Id, total and remaining duration of procssing the bagfile (in seconds) and also total and remaining number of processed messages  
 - The time interval of publishing the progress can be set using **~bagfile_progress_pub_interval** ROS param. The default value is **10.0** seconds.
- This is mostly useful for cases that the Cartographer progress needs to be monitored or visualized. 
 
## How I tested
In simulation