### PR TITLE
Fix pbstream exporting binaries

### DIFF
--- a/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
@@ -60,7 +60,8 @@ std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
   ::cartographer::mapping::proto::SerializedData proto;
   ::cartographer::mapping::ValueConversionTables conversion_lookup_tables;
   while (deserializer.ReadNextSerializedData(&proto)) {
-    if (proto.has_submap() && (Has2DGrid(proto.submap()) || Has3DGrids(proto.submap()))) {
+    if (proto.has_submap() &&
+        (Has2DGrid(proto.submap()) || Has3DGrids(proto.submap()))) {
       const auto& submap = proto.submap();
       const ::cartographer::mapping::SubmapId id{
           submap.submap_id().trajectory_id(),

--- a/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
@@ -49,6 +49,14 @@ DEFINE_double(resolution, 0.05, "Resolution of a grid cell in the drawn map.");
 namespace cartographer_ros {
 namespace {
 
+bool Has2dGrid(const ::cartographer::mapping::proto::Submap& submap) {
+  return submap.has_submap_2d() && submap.submap_2d().has_grid();
+}
+
+bool Has3dGrids(const ::cartographer::mapping::proto::Submap& submap) {
+  return submap.has_submap_3d() && submap.submap_3d().has_low_resolution_hybrid_grid() && submap.submap_3d().has_high_resolution_hybrid_grid();
+}
+
 std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
     const std::string& pbstream_filename, const double resolution) {
   ::cartographer::io::ProtoStreamReader reader(pbstream_filename);
@@ -60,7 +68,7 @@ std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
   ::cartographer::mapping::proto::SerializedData proto;
   ::cartographer::mapping::ValueConversionTables conversion_lookup_tables;
   while (deserializer.ReadNextSerializedData(&proto)) {
-    if (proto.has_submap()) {
+    if (proto.has_submap() && (Has2dGrid(proto.submap()) || Has3dGrids(proto.submap()))) {
       const auto& submap = proto.submap();
       const ::cartographer::mapping::SubmapId id{
           submap.submap_id().trajectory_id(),

--- a/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
@@ -49,14 +49,6 @@ DEFINE_double(resolution, 0.05, "Resolution of a grid cell in the drawn map.");
 namespace cartographer_ros {
 namespace {
 
-bool Has2dGrid(const ::cartographer::mapping::proto::Submap& submap) {
-  return submap.has_submap_2d() && submap.submap_2d().has_grid();
-}
-
-bool Has3dGrids(const ::cartographer::mapping::proto::Submap& submap) {
-  return submap.has_submap_3d() && submap.submap_3d().has_low_resolution_hybrid_grid() && submap.submap_3d().has_high_resolution_hybrid_grid();
-}
-
 std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
     const std::string& pbstream_filename, const double resolution) {
   ::cartographer::io::ProtoStreamReader reader(pbstream_filename);
@@ -68,7 +60,7 @@ std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
   ::cartographer::mapping::proto::SerializedData proto;
   ::cartographer::mapping::ValueConversionTables conversion_lookup_tables;
   while (deserializer.ReadNextSerializedData(&proto)) {
-    if (proto.has_submap() && (Has2dGrid(proto.submap()) || Has3dGrids(proto.submap()))) {
+    if (proto.has_submap() && (Has2DGrid(proto.submap()) || Has3DGrids(proto.submap()))) {
       const auto& submap = proto.submap();
       const ::cartographer::mapping::SubmapId id{
           submap.submap_id().trajectory_id(),

--- a/cartographer_ros/cartographer_ros/pbstream_to_ros_map_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_to_ros_map_main.cc
@@ -40,14 +40,6 @@ DEFINE_double(resolution, 0.05, "Resolution of a grid cell in the drawn map.");
 namespace cartographer_ros {
 namespace {
 
-bool Has2dGrid(const ::cartographer::mapping::proto::Submap& submap) {
-  return submap.has_submap_2d() && submap.submap_2d().has_grid();
-}
-
-bool Has3dGrids(const ::cartographer::mapping::proto::Submap& submap) {
-  return submap.has_submap_3d() && submap.submap_3d().has_low_resolution_hybrid_grid() && submap.submap_3d().has_high_resolution_hybrid_grid();
-}
-
 void Run(const std::string& pbstream_filename, const std::string& map_filestem,
          const double resolution) {
   ::cartographer::io::ProtoStreamReader reader(pbstream_filename);
@@ -61,7 +53,7 @@ void Run(const std::string& pbstream_filename, const std::string& map_filestem,
   ::cartographer::mapping::proto::SerializedData proto;
   ::cartographer::mapping::ValueConversionTables conversion_lookup_tables;
   while (deserializer.ReadNextSerializedData(&proto)) {
-    if (proto.has_submap() && (Has2dGrid(proto.submap()) || Has3dGrids(proto.submap()))) {
+    if (proto.has_submap() && (Has2DGrid(proto.submap()) || Has3DGrids(proto.submap()))) {
       const auto& submap = proto.submap();
       const ::cartographer::mapping::SubmapId id{
           submap.submap_id().trajectory_id(),

--- a/cartographer_ros/cartographer_ros/pbstream_to_ros_map_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_to_ros_map_main.cc
@@ -40,6 +40,14 @@ DEFINE_double(resolution, 0.05, "Resolution of a grid cell in the drawn map.");
 namespace cartographer_ros {
 namespace {
 
+bool Has2dGrid(const ::cartographer::mapping::proto::Submap& submap) {
+  return submap.has_submap_2d() && submap.submap_2d().has_grid();
+}
+
+bool Has3dGrids(const ::cartographer::mapping::proto::Submap& submap) {
+  return submap.has_submap_3d() && submap.submap_3d().has_low_resolution_hybrid_grid() && submap.submap_3d().has_high_resolution_hybrid_grid();
+}
+
 void Run(const std::string& pbstream_filename, const std::string& map_filestem,
          const double resolution) {
   ::cartographer::io::ProtoStreamReader reader(pbstream_filename);
@@ -53,7 +61,7 @@ void Run(const std::string& pbstream_filename, const std::string& map_filestem,
   ::cartographer::mapping::proto::SerializedData proto;
   ::cartographer::mapping::ValueConversionTables conversion_lookup_tables;
   while (deserializer.ReadNextSerializedData(&proto)) {
-    if (proto.has_submap()) {
+    if (proto.has_submap() && (Has2dGrid(proto.submap()) || Has3dGrids(proto.submap()))) {
       const auto& submap = proto.submap();
       const ::cartographer::mapping::SubmapId id{
           submap.submap_id().trajectory_id(),

--- a/cartographer_ros/cartographer_ros/pbstream_to_ros_map_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_to_ros_map_main.cc
@@ -53,7 +53,8 @@ void Run(const std::string& pbstream_filename, const std::string& map_filestem,
   ::cartographer::mapping::proto::SerializedData proto;
   ::cartographer::mapping::ValueConversionTables conversion_lookup_tables;
   while (deserializer.ReadNextSerializedData(&proto)) {
-    if (proto.has_submap() && (Has2DGrid(proto.submap()) || Has3DGrids(proto.submap()))) {
+    if (proto.has_submap() &&
+        (Has2DGrid(proto.submap()) || Has3DGrids(proto.submap()))) {
       const auto& submap = proto.submap();
       const ::cartographer::mapping::SubmapId id{
           submap.submap_id().trajectory_id(),

--- a/cartographer_ros/cartographer_ros/submap.cc
+++ b/cartographer_ros/cartographer_ros/submap.cc
@@ -58,7 +58,9 @@ bool Has2DGrid(const ::cartographer::mapping::proto::Submap& submap) {
 }
 
 bool Has3DGrids(const ::cartographer::mapping::proto::Submap& submap) {
-  return submap.has_submap_3d() && submap.submap_3d().has_low_resolution_hybrid_grid() && submap.submap_3d().has_high_resolution_hybrid_grid();
+  return submap.has_submap_3d() &&
+         submap.submap_3d().has_low_resolution_hybrid_grid() &&
+         submap.submap_3d().has_high_resolution_hybrid_grid();
 }
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/submap.cc
+++ b/cartographer_ros/cartographer_ros/submap.cc
@@ -53,4 +53,12 @@ std::unique_ptr<::cartographer::io::SubmapTextures> FetchSubmapTextures(
   return response;
 }
 
+bool Has2DGrid(const ::cartographer::mapping::proto::Submap& submap) {
+  return submap.has_submap_2d() && submap.submap_2d().has_grid();
+}
+
+bool Has3DGrids(const ::cartographer::mapping::proto::Submap& submap) {
+  return submap.has_submap_3d() && submap.submap_3d().has_low_resolution_hybrid_grid() && submap.submap_3d().has_high_resolution_hybrid_grid();
+}
+
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/submap.h
+++ b/cartographer_ros/cartographer_ros/submap.h
@@ -35,6 +35,9 @@ std::unique_ptr<::cartographer::io::SubmapTextures> FetchSubmapTextures(
     const ::cartographer::mapping::SubmapId& submap_id,
     ros::ServiceClient* client);
 
+bool Has2DGrid(const ::cartographer::mapping::proto::Submap& submap);
+bool Has3DGrids(const ::cartographer::mapping::proto::Submap& submap);
+
 }  // namespace cartographer_ros
 
 #endif  // CARTOGRAPHER_ROS_CARTOGRAPHER_ROS_SUBMAP_H


### PR DESCRIPTION
 googlecartographer/cartographer#1286 modified Submap::ToProto such that grids for unfinished submaps are no longer serialized. This commit fixes the breakage this introduced in the pbstream exporting binaries.