### PR TITLE
Add option to disable PoseExtrapolator

### DIFF
--- a/cartographer_ros/cartographer_ros/node_options.cc
+++ b/cartographer_ros/cartographer_ros/node_options.cc
@@ -40,6 +40,10 @@ NodeOptions CreateNodeOptions(
       lua_parameter_dictionary->GetDouble("pose_publish_period_sec");
   options.trajectory_publish_period_sec =
       lua_parameter_dictionary->GetDouble("trajectory_publish_period_sec");
+  if (lua_parameter_dictionary->HasKey("use_pose_extrapolator")) {
+    options.use_pose_extrapolator =
+        lua_parameter_dictionary->GetBool("use_pose_extrapolator");
+  }
   return options;
 }
 

--- a/cartographer_ros/cartographer_ros/node_options.h
+++ b/cartographer_ros/cartographer_ros/node_options.h
@@ -35,6 +35,7 @@ struct NodeOptions {
   double submap_publish_period_sec;
   double pose_publish_period_sec;
   double trajectory_publish_period_sec;
+  bool use_pose_extrapolator = true;
 };
 
 NodeOptions CreateNodeOptions(

--- a/cartographer_ros/configuration_files/backpack_2d.lua
+++ b/cartographer_ros/configuration_files/backpack_2d.lua
@@ -24,6 +24,7 @@ options = {
   odom_frame = "odom",
   provide_odom_frame = true,
   publish_frame_projected_to_2d = false,
+  use_pose_extrapolator = true,
   use_odometry = false,
   use_nav_sat = false,
   use_landmarks = false,

--- a/cartographer_ros/configuration_files/backpack_3d.lua
+++ b/cartographer_ros/configuration_files/backpack_3d.lua
@@ -24,6 +24,7 @@ options = {
   odom_frame = "odom",
   provide_odom_frame = true,
   publish_frame_projected_to_2d = false,
+  use_pose_extrapolator = true,
   use_odometry = false,
   use_nav_sat = false,
   use_landmarks = false,

--- a/cartographer_ros/configuration_files/pr2.lua
+++ b/cartographer_ros/configuration_files/pr2.lua
@@ -24,6 +24,7 @@ options = {
   odom_frame = "odom",
   provide_odom_frame = true,
   publish_frame_projected_to_2d = false,
+  use_pose_extrapolator = true,
   use_odometry = false,
   use_nav_sat = false,
   use_landmarks = false,

--- a/cartographer_ros/configuration_files/revo_lds.lua
+++ b/cartographer_ros/configuration_files/revo_lds.lua
@@ -24,6 +24,7 @@ options = {
   odom_frame = "odom",
   provide_odom_frame = true,
   publish_frame_projected_to_2d = false,
+  use_pose_extrapolator = true,
   use_odometry = false,
   use_nav_sat = false,
   use_landmarks = false,

--- a/cartographer_ros/configuration_files/taurob_tracker.lua
+++ b/cartographer_ros/configuration_files/taurob_tracker.lua
@@ -24,6 +24,7 @@ options = {
   odom_frame = "odom",
   provide_odom_frame = false,
   publish_frame_projected_to_2d = false,
+  use_pose_extrapolator = true,
   use_odometry = true,
   use_nav_sat = false,
   use_landmarks = false,


### PR DESCRIPTION
This is useful for tuning/debugging to rule out (simulated) time issues
(because published pose will then only depend on header times).
Another use case is when Cartographer runs on a separate machine
that has a different system clock than the sensors.