### PR TITLE
Removing unless from rviz_config argument

### DIFF
--- a/cartographer_ros/launch/offline_node.launch
+++ b/cartographer_ros/launch/offline_node.launch
@@ -17,7 +17,7 @@
 <launch>
   <arg name="bag_filenames"/>
   <arg name="no_rviz"/>
-  <arg unless="$(arg no_rviz)" name="rviz_config"/>
+  <arg name="rviz_config"/>
   <arg name="configuration_directory"/>
   <arg name="configuration_basenames"/>
   <arg name="urdf_filenames"/>


### PR DESCRIPTION
The roslaunch API throws an exception if setting the argument but not using it. 
This now forces any including launch files to provide an argument for it, even if it might not be used in the `no_rviz` case.