### PR TITLE
Disable forwarding proto stream by default in node_grpc_main.cc

### DIFF
--- a/cartographer_ros/cartographer_ros/cartographer_grpc/node_grpc_main.cc
+++ b/cartographer_ros/cartographer_ros/cartographer_grpc/node_grpc_main.cc
@@ -43,12 +43,13 @@ DEFINE_string(
 DEFINE_string(load_state_filename, "",
               "If non-empty, filename of a .pbstream file "
               "to load, containing a saved SLAM state. "
-              "Unless --forward_local_state_file is set, the filepath refers "
+              "Unless --upload_load_state_file is set, the filepath refers "
               "to the gRPC server's file system.");
 DEFINE_bool(load_frozen_state, true,
             "Load the saved state as frozen (non-optimized) trajectories.");
-DEFINE_bool(forward_local_state_file, false,
-            "Stream the saved state from a local path to the (remote) server.");
+DEFINE_bool(upload_load_state_file, false,
+            "Upload the .pbstream file from a local path to the (remote) gRPC "
+            "server instead of loading it from the server file system.");
 DEFINE_string(client_id, "",
               "Cartographer client ID to use when connecting to the server.");
 
@@ -67,15 +68,15 @@ void Run() {
   auto map_builder = absl::make_unique<::cartographer::cloud::MapBuilderStub>(
       FLAGS_server_address, FLAGS_client_id);
 
-  if (!FLAGS_load_state_filename.empty() && !FLAGS_forward_local_state_file) {
-    // TODO: add FLAGS_load_frozen_state
-    map_builder->LoadStateFromFile(FLAGS_load_state_filename);
+  if (!FLAGS_load_state_filename.empty() && !FLAGS_upload_load_state_file) {
+    map_builder->LoadStateFromFile(FLAGS_load_state_filename,
+                                   FLAGS_load_frozen_state);
   }
 
   Node node(node_options, std::move(map_builder), &tf_buffer,
             FLAGS_collect_metrics);
 
-  if (!FLAGS_load_state_filename.empty() && FLAGS_forward_local_state_file) {
+  if (!FLAGS_load_state_filename.empty() && FLAGS_upload_load_state_file) {
     node.LoadState(FLAGS_load_state_filename, FLAGS_load_frozen_state);
   }
 


### PR DESCRIPTION
...and use `LoadStateFromFile` from `MapBuilderStub`. The `LoadState` stub
that's used in `Node::LoadState` streams the state file instead, which can now
be used by explicitly setting the `--upload_load_state_file` flag.

Solves problems with the gRPC message size limit when loading large state files.