### PR TITLE
Fix submap pose marker toggling.

### DIFF
--- a/cartographer_rviz/cartographer_rviz/drawable_submap.cc
+++ b/cartographer_rviz/cartographer_rviz/drawable_submap.cc
@@ -81,6 +81,7 @@ DrawableSubmap::DrawableSubmap(const ::cartographer::mapping::SubmapId& id,
                                    ::rviz::MovableText::V_ABOVE);
   submap_id_text_node_->setPosition(ToOgre(kSubmapIdPosition));
   submap_id_text_node_->attachObject(&submap_id_text_);
+  TogglePoseMarkerVisibility();
   connect(this, SIGNAL(RequestSucceeded()), this, SLOT(UpdateSceneNode()));
 }
 


### PR DESCRIPTION
Set the visibility in the constructor, otherwise the setting won't have
an effect on newly created submap slices unless it's toggled again.
Somehow this got lost in #1012, sorry for that.