### PR TITLE
Only use ROS log sink in pbstream_map_publisher_main.cc

### DIFF
--- a/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
@@ -84,7 +84,6 @@ void Run(const std::string& pbstream_filename, const std::string& map_topic,
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
-  FLAGS_alsologtostderr = true;
   google::InitGoogleLogging(argv[0]);
   google::ParseCommandLineFlags(&argc, &argv, true);
 


### PR DESCRIPTION
Fixes double logging to stderr and rosout and makes it consistent with other
cartographer_ros nodes.