### PR TITLE
Work around wstool bug in build with Docker base image.

### DIFF
--- a/scripts/update_catkin_workspace.sh
+++ b/scripts/update_catkin_workspace.sh
@@ -20,4 +20,7 @@ set -o verbose
 . /opt/ros/${ROS_DISTRO}/setup.sh
 
 cd catkin_ws/src
+
+# Call 'status' as a workaround for https://github.com/vcstools/wstool/issues/77
+wstool status
 wstool update


### PR DESCRIPTION
We have already a cloned source space in the base image, which can be
buggy according to: https://github.com/vcstools/wstool/issues/77

This should unblock Travis and fix local builds.