### PR TITLE
Use absl::SkipEmpty() predicate.

### DIFF
--- a/cartographer_ros/cartographer_ros/assets_writer_main.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer_main.cc
@@ -55,7 +55,8 @@ int main(int argc, char** argv) {
       << "-pose_graph_filename is missing.";
 
   ::cartographer_ros::AssetsWriter asset_writer(
-      FLAGS_pose_graph_filename, absl::StrSplit(FLAGS_bag_filenames, ','),
+      FLAGS_pose_graph_filename,
+      absl::StrSplit(FLAGS_bag_filenames, ',', absl::SkipWhitespace()),
       FLAGS_output_file_prefix);
 
   asset_writer.Run(FLAGS_configuration_directory, FLAGS_configuration_basename,

--- a/cartographer_ros/cartographer_ros/assets_writer_main.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer_main.cc
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
 
   ::cartographer_ros::AssetsWriter asset_writer(
       FLAGS_pose_graph_filename,
-      absl::StrSplit(FLAGS_bag_filenames, ',', absl::SkipWhitespace()),
+      absl::StrSplit(FLAGS_bag_filenames, ',', absl::SkipEmpty()),
       FLAGS_output_file_prefix);
 
   asset_writer.Run(FLAGS_configuration_directory, FLAGS_configuration_basename,

--- a/cartographer_ros/cartographer_ros/offline_node.cc
+++ b/cartographer_ros/cartographer_ros/offline_node.cc
@@ -87,10 +87,10 @@ void RunOfflineNode(const MapBuilderFactory& map_builder_factory) {
   CHECK(!(FLAGS_bag_filenames.empty() && FLAGS_load_state_filename.empty()))
       << "-bag_filenames and -load_state_filename cannot both be unspecified.";
   const std::vector<std::string> bag_filenames =
-      absl::StrSplit(FLAGS_bag_filenames, ',');
+      absl::StrSplit(FLAGS_bag_filenames, ',', absl::SkipWhitespace());
   cartographer_ros::NodeOptions node_options;
-  const std::vector<std::string> configuration_basenames =
-      absl::StrSplit(FLAGS_configuration_basenames, ',');
+  const std::vector<std::string> configuration_basenames = absl::StrSplit(
+      FLAGS_configuration_basenames, ',', absl::SkipWhitespace());
   std::vector<TrajectoryOptions> bag_trajectory_options(1);
   std::tie(node_options, bag_trajectory_options.at(0)) =
       LoadOptions(FLAGS_configuration_directory, configuration_basenames.at(0));
@@ -123,7 +123,7 @@ void RunOfflineNode(const MapBuilderFactory& map_builder_factory) {
 
   std::vector<geometry_msgs::TransformStamped> urdf_transforms;
   const std::vector<std::string> urdf_filenames =
-      absl::StrSplit(FLAGS_urdf_filenames, ',');
+      absl::StrSplit(FLAGS_urdf_filenames, ',', absl::SkipWhitespace());
   for (const auto& urdf_filename : urdf_filenames) {
     const auto current_urdf_transforms =
         ReadStaticTransformsFromUrdf(urdf_filename, &tf_buffer);

--- a/cartographer_ros/cartographer_ros/offline_node.cc
+++ b/cartographer_ros/cartographer_ros/offline_node.cc
@@ -87,10 +87,10 @@ void RunOfflineNode(const MapBuilderFactory& map_builder_factory) {
   CHECK(!(FLAGS_bag_filenames.empty() && FLAGS_load_state_filename.empty()))
       << "-bag_filenames and -load_state_filename cannot both be unspecified.";
   const std::vector<std::string> bag_filenames =
-      absl::StrSplit(FLAGS_bag_filenames, ',', absl::SkipWhitespace());
+      absl::StrSplit(FLAGS_bag_filenames, ',', absl::SkipEmpty());
   cartographer_ros::NodeOptions node_options;
-  const std::vector<std::string> configuration_basenames = absl::StrSplit(
-      FLAGS_configuration_basenames, ',', absl::SkipWhitespace());
+  const std::vector<std::string> configuration_basenames =
+      absl::StrSplit(FLAGS_configuration_basenames, ',', absl::SkipEmpty());
   std::vector<TrajectoryOptions> bag_trajectory_options(1);
   std::tie(node_options, bag_trajectory_options.at(0)) =
       LoadOptions(FLAGS_configuration_directory, configuration_basenames.at(0));
@@ -123,7 +123,7 @@ void RunOfflineNode(const MapBuilderFactory& map_builder_factory) {
 
   std::vector<geometry_msgs::TransformStamped> urdf_transforms;
   const std::vector<std::string> urdf_filenames =
-      absl::StrSplit(FLAGS_urdf_filenames, ',', absl::SkipWhitespace());
+      absl::StrSplit(FLAGS_urdf_filenames, ',', absl::SkipEmpty());
   for (const auto& urdf_filename : urdf_filenames) {
     const auto current_urdf_transforms =
         ReadStaticTransformsFromUrdf(urdf_filename, &tf_buffer);


### PR DESCRIPTION
Fixes empty splits for default "" arguments. Follow up to #1026, thx to @ojura.