### PR TITLE
Adding launch file arg for launch-prefix to offline nodes

### DIFF
--- a/cartographer_ros/launch/offline_backpack_2d.launch
+++ b/cartographer_ros/launch/offline_backpack_2d.launch
@@ -21,6 +21,7 @@
   <arg name="configuration_directory" default="$(find cartographer_ros)/configuration_files"/>
   <arg name="configuration_basenames" default="backpack_2d.lua"/>
   <arg name="urdf_filenames" default="$(find cartographer_ros)/urdf/backpack_2d.urdf"/>
+  <arg name="launch_prefix" default=""/>
 
   <remap from="echoes" to="horizontal_laser_2d"/>
   <include file="$(find cartographer_ros)/launch/offline_node.launch">
@@ -30,5 +31,6 @@
     <arg name="configuration_directory" value="$(arg configuration_directory)"/>
     <arg name="configuration_basenames" value="$(arg configuration_basenames)"/>
     <arg name="urdf_filenames" value="$(arg urdf_filenames)"/>
+    <arg name="launch_prefix" value="$(arg launch_prefix)"/>
   </include>
 </launch>

--- a/cartographer_ros/launch/offline_backpack_3d.launch
+++ b/cartographer_ros/launch/offline_backpack_3d.launch
@@ -21,6 +21,7 @@
   <arg name="configuration_directory" default="$(find cartographer_ros)/configuration_files"/>
   <arg name="configuration_basenames" default="backpack_3d.lua"/>
   <arg name="urdf_filenames" default="$(find cartographer_ros)/urdf/backpack_3d.urdf"/>
+  <arg name="launch_prefix" default=""/>
 
   <remap from="points2_1" to="horizontal_laser_3d" />
   <remap from="points2_2" to="vertical_laser_3d" />
@@ -31,5 +32,6 @@
     <arg name="configuration_directory" value="$(arg configuration_directory)"/>
     <arg name="configuration_basenames" value="$(arg configuration_basenames)"/>
     <arg name="urdf_filenames" value="$(arg urdf_filenames)"/>
+    <arg name="launch_prefix" value="$(arg launch_prefix)"/>
   </include>
 </launch>

--- a/cartographer_ros/launch/offline_node.launch
+++ b/cartographer_ros/launch/offline_node.launch
@@ -21,6 +21,7 @@
   <arg name="configuration_directory"/>
   <arg name="configuration_basenames"/>
   <arg name="urdf_filenames"/>
+  <arg name="launch_prefix"/>
 
   <param name="/use_sim_time" value="true" />
 
@@ -44,5 +45,6 @@
           -configuration_basenames $(arg configuration_basenames)
           -urdf_filenames $(arg urdf_filenames)
           -bag_filenames $(arg bag_filenames)"
+      launch-prefix="$(arg launch_prefix)"
       output="screen"/>
 </launch>


### PR DESCRIPTION
Useful for debugging with gdb or profiling, e.g. with perf.