### PR TITLE
Consider waiting trajectories with a sensor bridge as active.

### DIFF
--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -203,11 +203,9 @@ MapBuilderBridge::GetTrajectoryStates() {
   // Add active trajectories that are not yet in the pose graph, but are e.g.
   // waiting for input sensor data and thus already have a sensor bridge.
   for (const auto& sensor_bridge : sensor_bridges_) {
-    const int trajectory_id = sensor_bridge.first;
-    if (!trajectory_states.count(trajectory_id)) {
-      trajectory_states[trajectory_id] =
-          ::cartographer::mapping::PoseGraph::TrajectoryState::ACTIVE;
-    }
+    trajectory_states.insert(std::make_pair(
+        sensor_bridge.first,
+        ::cartographer::mapping::PoseGraph::TrajectoryState::ACTIVE));
   }
   return trajectory_states;
 }

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -199,7 +199,17 @@ void MapBuilderBridge::HandleSubmapQuery(
 
 std::map<int, ::cartographer::mapping::PoseGraphInterface::TrajectoryState>
 MapBuilderBridge::GetTrajectoryStates() {
-  return map_builder_->pose_graph()->GetTrajectoryStates();
+  auto trajectory_states = map_builder_->pose_graph()->GetTrajectoryStates();
+  // Add active trajectories that are not yet in the pose graph, but are e.g.
+  // waiting for input sensor data and thus already have a sensor bridge.
+  for (const auto& sensor_bridge : sensor_bridges_) {
+    const int trajectory_id = sensor_bridge.first;
+    if (!trajectory_states.count(trajectory_id)) {
+      trajectory_states[trajectory_id] =
+          ::cartographer::mapping::PoseGraph::TrajectoryState::ACTIVE;
+    }
+  }
+  return trajectory_states;
 }
 
 cartographer_ros_msgs::SubmapList MapBuilderBridge::GetSubmapList() {


### PR DESCRIPTION
Fixes https://github.com/googlecartographer/cartographer/issues/1367

Trajectories that didn't start SLAMing yet couldn't be finished, e.g. 
due to waiting for sensor data. They don't appear in the trajectory 
states list of the pose graph yet but already have a trajectory builder.