### PR TITLE
Add git dependency to package.xml (for Abseil build).

### DIFF
--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -36,6 +36,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>git</build_depend>
   <build_depend>google-mock</build_depend>
   <build_depend>g++-static</build_depend>
   <build_depend>protobuf-dev</build_depend>

--- a/cartographer_rviz/package.xml
+++ b/cartographer_rviz/package.xml
@@ -36,6 +36,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>git</build_depend>
   <build_depend>g++-static</build_depend>
 
   <depend version_gte="1.0.0">cartographer</depend>


### PR DESCRIPTION
Otherwise, building on a ROS buildfarm (with bloom) fails with:
`error: could not find git for clone of abseil`