### PR TITLE
Don't run final optimization in visualize_pbstream.launch

### DIFF
--- a/cartographer_ros/configuration_files/visualize_pbstream.lua
+++ b/cartographer_ros/configuration_files/visualize_pbstream.lua
@@ -18,4 +18,8 @@ POSE_GRAPH.constraint_builder.sampling_ratio = 0
 POSE_GRAPH.global_sampling_ratio = 0
 POSE_GRAPH.optimize_every_n_nodes = 0
 
+-- In case there are active publishers, drop all sensor data for visualization.
+options.imu_sampling_ratio = 0
+options.rangefinder_sampling_ratio = 0
+
 return options

--- a/cartographer_ros/configuration_files/visualize_pbstream.lua
+++ b/cartographer_ros/configuration_files/visualize_pbstream.lua
@@ -18,8 +18,4 @@ POSE_GRAPH.constraint_builder.sampling_ratio = 0
 POSE_GRAPH.global_sampling_ratio = 0
 POSE_GRAPH.optimize_every_n_nodes = 0
 
--- In case there are active publishers, drop all sensor data for visualization.
-options.imu_sampling_ratio = 0
-options.rangefinder_sampling_ratio = 0
-
 return options

--- a/cartographer_ros/launch/visualize_pbstream.launch
+++ b/cartographer_ros/launch/visualize_pbstream.launch
@@ -22,7 +22,8 @@
           -configuration_directory $(find cartographer_ros)/configuration_files
           -configuration_basename visualize_pbstream.lua
           -load_state_filename $(arg pbstream_filename)
-          -load_frozen_state=false"
+          -load_frozen_state=false
+          -start_trajectory_with_default_topics=false"
       output="screen">
   </node>
 </launch>

--- a/cartographer_ros/launch/visualize_pbstream.launch
+++ b/cartographer_ros/launch/visualize_pbstream.launch
@@ -17,11 +17,10 @@
 <launch>
   <node name="rviz" pkg="rviz" type="rviz" required="true"
       args="-d $(find cartographer_ros)/configuration_files/demo_2d.rviz" />
-  <node name="cartographer_offline_node" pkg="cartographer_ros"
-      type="cartographer_offline_node" args="
+  <node name="cartographer_node" pkg="cartographer_ros"
+      type="cartographer_node" args="
           -configuration_directory $(find cartographer_ros)/configuration_files
-          -configuration_basenames visualize_pbstream.lua
-          -keep_running=true
+          -configuration_basename visualize_pbstream.lua
           -load_state_filename $(arg pbstream_filename)
           -load_frozen_state=false"
       output="screen">


### PR DESCRIPTION
Replaces the offline node with the normal node.

The problem is that the offline node immediately runs a final
optimization with `visualize_pbstream.lua`, which is most likely not the
configuration that was used to generate the pbstream. This can lead to
effects like distortions in the map e.g. due to different weights, even
though the actual saved state is fine.