### PR TITLE
Update clang-format to new Google style.

### DIFF
--- a/cartographer_ros/cartographer_ros/msg_conversion_test.cc
+++ b/cartographer_ros/cartographer_ros/msg_conversion_test.cc
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+#include "cartographer_ros/msg_conversion.h"
+
 #include <cmath>
 #include <random>
 
 #include "cartographer/transform/rigid_transform_test_helpers.h"
-#include "cartographer_ros/msg_conversion.h"
 #include "cartographer_ros/time_conversion.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/cartographer_ros/cartographer_ros/offline_node.cc
+++ b/cartographer_ros/cartographer_ros/offline_node.cc
@@ -22,6 +22,7 @@
 #include <sys/resource.h>
 #endif
 #include <time.h>
+
 #include <chrono>
 
 #include "absl/strings/str_split.h"

--- a/cartographer_ros/cartographer_ros/playable_bag.h
+++ b/cartographer_ros/cartographer_ros/playable_bag.h
@@ -16,11 +16,12 @@
 
 #ifndef CARTOGRAPHER_ROS_CARTOGRAPHER_ROS_PLAYABLE_BAG_H
 #define CARTOGRAPHER_ROS_CARTOGRAPHER_ROS_PLAYABLE_BAG_H
+#include <cartographer_ros_msgs/BagfileProgress.h>
+#include <ros/node_handle.h>
+
 #include <functional>
 #include <queue>
 
-#include <cartographer_ros_msgs/BagfileProgress.h>
-#include <ros/node_handle.h>
 #include "rosbag/bag.h"
 #include "rosbag/view.h"
 #include "tf2_ros/buffer.h"

--- a/cartographer_ros/cartographer_ros/tf_bridge.cc
+++ b/cartographer_ros/cartographer_ros/tf_bridge.cc
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "absl/memory/memory.h"
-
-#include "cartographer_ros/msg_conversion.h"
 #include "cartographer_ros/tf_bridge.h"
+
+#include "absl/memory/memory.h"
+#include "cartographer_ros/msg_conversion.h"
 
 namespace cartographer_ros {
 

--- a/cartographer_ros/cartographer_ros/tf_bridge.h
+++ b/cartographer_ros/cartographer_ros/tf_bridge.h
@@ -20,9 +20,8 @@
 #include <memory>
 
 #include "cartographer/transform/rigid_transform.h"
-#include "tf2_ros/buffer.h"
-
 #include "cartographer_ros/time_conversion.h"
+#include "tf2_ros/buffer.h"
 
 namespace cartographer_ros {
 


### PR DESCRIPTION
Apparently the format bot uses a bleeding edge clang-format that uses
the new Google style and reformats a bunch of files in every PR. This is
an empty commit to trigger this in a separate commit.

See https://github.com/llvm-mirror/clang/commit/62e3198c4f5490a1c60ba51d81fe2e1f0dc99135