### PR TITLE
Unify trajectory state checks for service handlers.

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -466,51 +466,53 @@ bool Node::ValidateTopicNames(
   return true;
 }
 
+cartographer_ros_msgs::StatusResponse Node::CheckTrajectoryState(
+    int trajectory_id, std::set<TrajectoryState> valid_states) {
+  const auto trajectory_states = map_builder_bridge_.GetTrajectoryStates();
+  cartographer_ros_msgs::StatusResponse status_response;
+
+  if (!(trajectory_states.count(trajectory_id))) {
+    status_response.message =
+        absl::StrCat("Trajectory ", trajectory_id, " doesn't exist.");
+    status_response.code = cartographer_ros_msgs::StatusCode::NOT_FOUND;
+    return status_response;
+  }
+
+  const auto trajectory_state = trajectory_states.at(trajectory_id);
+  const std::map<TrajectoryState, std::string> state_to_string = {
+      {TrajectoryState::ACTIVE, "ACTIVE"},
+      {TrajectoryState::FINISHED, "FINISHED"},
+      {TrajectoryState::FROZEN, "FROZEN"},
+      {TrajectoryState::DELETED, "DELETED"},
+  };
+  status_response.message =
+      absl::StrCat("Trajectory ", trajectory_id, " is in '",
+                   state_to_string.at(trajectory_state), "' state.");
+  if (valid_states.count(trajectory_state)) {
+    status_response.code = cartographer_ros_msgs::StatusCode::OK;
+  } else {
+    status_response.code = cartographer_ros_msgs::StatusCode::INVALID_ARGUMENT;
+  }
+  return status_response;
+}
+
 cartographer_ros_msgs::StatusResponse Node::FinishTrajectoryUnderLock(
     const int trajectory_id) {
-  auto trajectory_states = map_builder_bridge_.GetTrajectoryStates();
-
   cartographer_ros_msgs::StatusResponse status_response;
   if (trajectories_scheduled_for_finish_.count(trajectory_id)) {
-    const std::string message = absl::StrCat("Trajectory ", trajectory_id,
-                                             " already pending to finish.");
+    status_response.message = absl::StrCat("Trajectory ", trajectory_id,
+                                           " already pending to finish.");
     status_response.code = cartographer_ros_msgs::StatusCode::OK;
-    status_response.message = message;
-    LOG(INFO) << message;
+    LOG(INFO) << status_response.message;
     return status_response;
   }
 
   // First, check if we can actually finish the trajectory.
-  if (!(trajectory_states.count(trajectory_id))) {
-    const std::string error =
-        absl::StrCat("Trajectory ", trajectory_id, " doesn't exist.");
-    LOG(ERROR) << error;
-    status_response.code = cartographer_ros_msgs::StatusCode::NOT_FOUND;
-    status_response.message = error;
-    return status_response;
-  } else if (trajectory_states.at(trajectory_id) == TrajectoryState::FROZEN) {
-    const std::string error =
-        absl::StrCat("Trajectory ", trajectory_id, " is frozen.");
-    LOG(ERROR) << error;
-    status_response.code = cartographer_ros_msgs::StatusCode::INVALID_ARGUMENT;
-    status_response.message = error;
-    return status_response;
-  } else if (trajectory_states.at(trajectory_id) == TrajectoryState::FINISHED) {
-    const std::string error = absl::StrCat("Trajectory ", trajectory_id,
-                                           " has already been finished.");
-    LOG(ERROR) << error;
-    status_response.code =
-        cartographer_ros_msgs::StatusCode::RESOURCE_EXHAUSTED;
-    status_response.message = error;
-    return status_response;
-  } else if (trajectory_states.at(trajectory_id) == TrajectoryState::DELETED) {
-    const std::string error =
-        absl::StrCat("Trajectory ", trajectory_id, " has been deleted.");
-    LOG(ERROR) << error;
-    status_response.code =
-        cartographer_ros_msgs::StatusCode::RESOURCE_EXHAUSTED;
-    status_response.message = error;
-    return status_response;
+  cartographer_ros_msgs::StatusResponse check_response = CheckTrajectoryState(
+      trajectory_id, {TrajectoryState::ACTIVE} /* valid states */);
+  if (check_response.code != cartographer_ros_msgs::StatusCode::OK) {
+    LOG(ERROR) << "Can't finish trajectory: "<< check_response.message;
+    return check_response;
   }
 
   // Shutdown the subscribers of this trajectory.

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -511,7 +511,7 @@ cartographer_ros_msgs::StatusResponse Node::FinishTrajectoryUnderLock(
   cartographer_ros_msgs::StatusResponse check_response = CheckTrajectoryState(
       trajectory_id, {TrajectoryState::ACTIVE} /* valid states */);
   if (check_response.code != cartographer_ros_msgs::StatusCode::OK) {
-    LOG(ERROR) << "Can't finish trajectory: "<< check_response.message;
+    LOG(ERROR) << "Can't finish trajectory: " << check_response.message;
     return check_response;
   }
 

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -175,9 +175,10 @@ class Node {
   void MaybeWarnAboutTopicMismatch(const ::ros::WallTimerEvent&);
 
   // Helper function for service handlers that need to check trajectory states.
-  cartographer_ros_msgs::StatusResponse CheckTrajectoryState(
+  cartographer_ros_msgs::StatusResponse TrajectoryStateToStatus(
       int trajectory_id,
-      std::set<cartographer::mapping::PoseGraphInterface::TrajectoryState>
+      const std::set<
+          cartographer::mapping::PoseGraphInterface::TrajectoryState>&
           valid_states);
   const NodeOptions node_options_;
 

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -174,6 +174,11 @@ class Node {
       int trajectory_id) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   void MaybeWarnAboutTopicMismatch(const ::ros::WallTimerEvent&);
 
+  // Helper function for service handlers that need to check trajectory states.
+  cartographer_ros_msgs::StatusResponse CheckTrajectoryState(
+      int trajectory_id,
+      std::set<cartographer::mapping::PoseGraphInterface::TrajectoryState>
+          valid_states);
   const NodeOptions node_options_;
 
   tf2_ros::TransformBroadcaster tf_broadcaster_;


### PR DESCRIPTION
Some service handlers need to check if a trajectory is in a valid
state for the requested operation. If it's not, they return an error
response.

`Node::CheckTrajectoryState` removes code duplication in handlers.
It generates a human-readable response message and sets the
status code depending on whether the trajectory is in one of the 
`valid_states`.