### PR TITLE
Add function to set the initial pose from RVIZ for pure localization mode

### DIFF
--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -91,6 +91,17 @@ install(TARGETS cartographer_pbstream_map_publisher
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+google_binary(set_initpose_from_rviz
+  SRCS
+  set_initpose_main.cc
+)
+
+install(TARGETS set_initpose_from_rviz
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 google_binary(cartographer_dev_pbstream_trajectories_to_rosbag
   SRCS
   dev/pbstream_trajectories_to_rosbag_main.cc

--- a/cartographer_ros/cartographer_ros/set_initpose_main.cc
+++ b/cartographer_ros/cartographer_ros/set_initpose_main.cc
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "gflags/gflags.h"
+#include "cartographer/common/configuration_file_resolver.h"
+#include "cartographer/io/proto_stream.h"
+#include "cartographer/mapping/map_builder.h"
+#include "cartographer_ros/node_options.h"
+#include "cartographer_ros/node_constants.h"
+#include "cartographer_ros/ros_log_sink.h"
+#include "cartographer_ros_msgs/StartTrajectory.h"
+#include "cartographer_ros_msgs/FinishTrajectory.h"
+#include "cartographer_ros_msgs/StatusCode.h"
+
+#include "ros/ros.h"
+#include "std_msgs/String.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "geometry_msgs/PoseWithCovarianceStamped.h"
+
+#include <string>
+#include <vector>
+
+DEFINE_string(configuration_directory, "",
+              "First directory in which configuration files are searched, "
+              "second is always the Cartographer installation to allow "
+              "including files from there.");
+DEFINE_string(configuration_basename, "",
+              "Basename, i.e. not containing any directory prefix, of the "
+              "configuration file.");
+
+DEFINE_string(load_state_filename, "",
+              "Filename of a pbstream to draw a map from.");
+
+namespace
+{
+  int current_trajectory_id_ = 1;
+  std::unique_ptr<cartographer::mapping::MapBuilder> map_builder_;
+}
+
+
+// subscribe callback function from Rviz
+void move_base_simple_callback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& msg){
+  ::ros::NodeHandle nh;
+
+  // stop the old trajectory
+  ::ros::ServiceClient client_finish_trajectroy = nh.serviceClient<cartographer_ros_msgs::FinishTrajectory>(cartographer_ros::kFinishTrajectoryServiceName);
+  cartographer_ros_msgs::FinishTrajectory srv_finish_trajectroy;
+  srv_finish_trajectroy.request.trajectory_id = current_trajectory_id_++;
+
+  if (!client_finish_trajectroy.call(srv_finish_trajectroy)) {
+    LOG(ERROR) << "Failed to call " << cartographer_ros::kFinishTrajectoryServiceName << ".";
+  }
+  if (srv_finish_trajectroy.response.status.code != cartographer_ros_msgs::StatusCode::OK) {
+    LOG(ERROR) << "Error finishing trajectory - message: '"
+               << srv_finish_trajectroy.response.status.message
+               << "' (status code: " << std::to_string(srv_finish_trajectroy.response.status.code)
+               << ").";
+    return;
+  }
+
+  // start a new trajectory
+  const auto node_poses = map_builder_->pose_graph()->GetTrajectoryNodePoses();
+
+  // get the start pose of the trajectory0 w.r.t /map
+  const auto traj_ref_pose = node_poses.BeginOfTrajectory(0)->data.global_pose;
+  tf2::Transform traj_ref_tf;
+  traj_ref_tf.getOrigin() = tf2::Vector3(traj_ref_pose.translation().x(), traj_ref_pose.translation().y(), traj_ref_pose.translation().z());
+  traj_ref_tf.setRotation(tf2::Quaternion(traj_ref_pose.rotation().x(), traj_ref_pose.rotation().y(), traj_ref_pose.rotation().z(), traj_ref_pose.rotation().w()));
+
+  // get init pose w.r.t /map
+  tf2::Transform map_tf;
+  tf2::fromMsg(msg->pose.pose, map_tf);
+
+  // have to set the corret z for the initial pose, since Rviz can only assign 2D position
+  const auto submap_poses = map_builder_->pose_graph()->GetAllSubmapPoses();
+  double min_dist = 1e6;
+  for(auto itr = submap_poses.begin(); itr != submap_poses.end(); ++itr)
+    {
+      // get the origin of submap w.r.t /map
+      tf2::Vector3 submap_origin(itr->data.pose.translation().x(),
+                                 itr->data.pose.translation().y(),
+                                 itr->data.pose.translation().z());
+
+      // calculate the distance between submap origin and initial pose
+      tf2::Vector3 delta_pos = submap_origin - map_tf.getOrigin();
+      delta_pos.setZ(0); // only check horinzontal location
+
+      // find the best submap, which is closest to the initial pose
+      // and assign the height (i.e. z value) of this submap to the initial pose
+      if(delta_pos.length() < min_dist)
+        {
+          map_tf.getOrigin().setZ(submap_origin.z());
+          min_dist = delta_pos.length();
+        }
+    }
+
+  tf2::Transform relative_initpose_tf = traj_ref_tf.inverse() * map_tf;
+
+  // set the start trajectory service call
+  ::ros::ServiceClient client_start_trajectroy = nh.serviceClient<cartographer_ros_msgs::StartTrajectory>(cartographer_ros::kStartTrajectoryServiceName);
+  cartographer_ros_msgs::StartTrajectory srv_start_trajectroy;
+  srv_start_trajectroy.request.configuration_directory = FLAGS_configuration_directory;
+  srv_start_trajectroy.request.configuration_basename = FLAGS_configuration_basename;
+
+  srv_start_trajectroy.request.relative_to_trajectory_id = 0; //frozen trajectory
+  srv_start_trajectroy.request.use_initial_pose = true;
+  tf2::toMsg(relative_initpose_tf, srv_start_trajectroy.request.initial_pose);
+
+  if (!client_start_trajectroy.call(srv_start_trajectroy)) {
+    LOG(ERROR) << "Failed to call " << cartographer_ros::kStartTrajectoryServiceName << ".";
+  }
+  if (srv_start_trajectroy.response.status.code != cartographer_ros_msgs::StatusCode::OK) {
+    LOG(ERROR) << "Error starting trajectory - message: '"
+               << srv_start_trajectroy.response.status.message
+               << "' (status code: " << std::to_string(srv_start_trajectroy.response.status.code)
+               << ").";
+  }
+}
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+
+  google::SetUsageMessage(
+      "\n\n"
+      "Convenience tool around the start_trajectory service. This takes a Lua "
+      "file that is accepted by the node as well and starts a new trajectory "
+      "using its settings.\n");
+
+  google::ParseCommandLineFlags(&argc, &argv, true);
+
+  CHECK(!FLAGS_configuration_basename.empty())
+      << "-configuration_basename is missing.";
+
+  CHECK(!FLAGS_configuration_directory.empty())
+      << "-configuration_directory is missing.";
+
+  // load pbstream
+  ::cartographer::io::ProtoStreamReader reader(FLAGS_load_state_filename);
+  cartographer_ros::NodeOptions node_options;
+  std::tie(node_options, std::ignore) = cartographer_ros::LoadOptions(FLAGS_configuration_directory, FLAGS_configuration_basename);
+  map_builder_ =  absl::make_unique<cartographer::mapping::MapBuilder>(node_options.map_builder_options);
+  map_builder_->LoadState(&reader, true);
+
+  ::ros::init(argc, argv, "cartographer_start_trajectory");
+  ::ros::start();
+
+  ::ros::NodeHandle nh;
+  ::ros::Subscriber sub_move_base_simple = nh.subscribe<geometry_msgs::PoseWithCovarianceStamped>("/initialpose", 1, &move_base_simple_callback);
+  ::ros::spin();
+}
+

--- a/cartographer_ros/launch/demo_backpack_2d_localization.launch
+++ b/cartographer_ros/launch/demo_backpack_2d_localization.launch
@@ -15,6 +15,8 @@
 -->
 
 <launch>
+  <arg name="rosbag" default="true" />
+
   <param name="/use_sim_time" value="true" />
 
   <param name="robot_description"
@@ -32,11 +34,18 @@
     <remap from="echoes" to="horizontal_laser_2d" />
   </node>
 
+  <node name="set_initpose" pkg="cartographer_ros" type="set_initpose_from_rviz" output="screen"
+        args="
+              -configuration_directory $(find cartographer_ros)/configuration_files
+              -configuration_basename backpack_2d_localization.lua
+              -load_state_filename $(arg load_state_filename)" >
+  </node>
+
   <node name="cartographer_occupancy_grid_node" pkg="cartographer_ros"
       type="cartographer_occupancy_grid_node" args="-resolution 0.05" />
 
   <node name="rviz" pkg="rviz" type="rviz" required="true"
       args="-d $(find cartographer_ros)/configuration_files/demo_2d.rviz" />
   <node name="playbag" pkg="rosbag" type="play"
-      args="--clock $(arg bag_filename)" />
+      args="--clock $(arg bag_filename)" if="$(arg rosbag)"/>
 </launch>

--- a/cartographer_ros/launch/demo_backpack_3d_localization.launch
+++ b/cartographer_ros/launch/demo_backpack_3d_localization.launch
@@ -15,6 +15,8 @@
 -->
 
 <launch>
+  <arg name="rosbag" default="true" />
+
   <param name="/use_sim_time" value="true" />
 
   <param name="robot_description"
@@ -33,11 +35,19 @@
     <remap from="points2_2" to="vertical_laser_3d" />
   </node>
 
+  <node name="set_initpose" pkg="cartographer_ros" type="set_initpose_from_rviz" output="screen"
+        args="
+              -configuration_directory $(find cartographer_ros)/configuration_files
+              -configuration_basename backpack_3d_localization.lua
+              -load_state_filename $(arg load_state_filename)" >
+  </node>
+
   <node name="cartographer_occupancy_grid_node" pkg="cartographer_ros"
       type="cartographer_occupancy_grid_node" args="-resolution 0.05" />
 
   <node name="rviz" pkg="rviz" type="rviz" required="true"
       args="-d $(find cartographer_ros)/configuration_files/demo_3d.rviz" />
   <node name="playbag" pkg="rosbag" type="play"
-      args="--clock $(arg bag_filename)" />
+      args="--clock $(arg bag_filename)" if="$(arg rosbag)"/>
+
 </launch>


### PR DESCRIPTION
As mentioned in the closed PR #637, manually "tuning" of the robot initial pose from GUI (e.g. Rviz) is a very important function for home service robot, which is supported by the ROS default localization method AMCL.

I hope this PR can facilitate the development of [this RFC](https://github.com/googlecartographer/rfcs/pull/17).

To test my commit, please try following commands
1. First follow the tutorial about  [pure localization](https://google-cartographer-ros.readthedocs.io/en/latest/demos.html#pure-localization) to download rosbags and build the map (.pbstream).
2. Then run following command instead:
```  
$ roslaunch cartographer_ros demo_backpack_2d_localization.launch \
   load_state_filename:=${HOME}/Downloads/b3-2016-04-05-13-54-42.bag.pbstream \
   rosbag:=false
```
3. Use the icon `2D  Pose Estimation` in Rviz to set the initial pose as shown in following image.
![Screenshot from 2019-05-12 19-06-45](https://user-images.githubusercontent.com/3666095/57580802-2c3e6780-74e9-11e9-915d-04b27c957961.png)

4. Play the rosbag:
```
$ rosbag play ${HOME}/Downloads/b2-2016-04-27-12-31-41.bag --clock -s 320
```

The whole sequence can be found in [this video](https://drive.google.com/open?id=12B8R-uFGNB9CUBnLMQyslvX1pia1HEJP), and you can also try the 3D mode in this same way.

We have confirmed the 3D performance with our original data, please check [this video](https://drive.google.com/open?id=1lKfQ2_beHCf93W3l0xbGSONjK53sFfTK).

**Limitations**:  the multi-floor map is not supported, since we can not assign the height (i.e. z value) from Rviz. 
