### PR TITLE
Eigen alignment fix + copy prevention reference

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -235,7 +235,7 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
         carto::sensor::TimedPointCloud point_cloud;
         point_cloud.reserve(trajectory_data.local_slam_data->range_data_in_local
                                 .returns.size());
-        for (const cartographer::sensor::RangefinderPoint point :
+        for (const cartographer::sensor::RangefinderPoint& point :
              trajectory_data.local_slam_data->range_data_in_local.returns) {
           point_cloud.push_back(cartographer::sensor::ToTimedRangefinderPoint(
               point, 0.f /* time */));

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -213,7 +213,7 @@ class Node {
   };
 
   // These are keyed with 'trajectory_id'.
-  std::map<int, ::cartographer::mapping::PoseExtrapolator> extrapolators_;
+  std::map<int, ::cartographer::mapping::PoseExtrapolator, std::less<int>,  Eigen::aligned_allocator<std::pair<const int, ::cartographer::mapping::PoseExtrapolator> > > extrapolators_;
   std::map<int, ::ros::Time> last_published_tf_stamps_;
   std::unordered_map<int, TrajectorySensorSamplers> sensor_samplers_;
   std::unordered_map<int, std::vector<Subscriber>> subscribers_;


### PR DESCRIPTION
- Added Eigen alignment fix for Extrapolator allocation (useful on AVX systems). Sometimes Eigen structures can create a mess in linked object code ([cartographer-project/#1909](https://github.com/cartographer-project/cartographer/pull/1910)). This fixes one of the cases which leads Cartographer to crash during startup on some AVX systems.
- Added copy prevention reference to the loop (`clangd` static analyzer)
